### PR TITLE
fix(install): guard empty langs array under bash 3.2 + set -u

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1279,7 +1279,10 @@ install_rules() {
     fi
     # If RULE_LANGS_EXPLICIT=true and RULE_LANGS is empty, skip language rules
 
-    for lang in "${langs[@]}"; do
+    # Use `"${arr[@]+"${arr[@]}"}"` for langs: macOS ships bash 3.2 where the
+    # plain form aborts under `set -u` when the array is empty (selective install
+    # picking rules-common with no language rules).
+    for lang in "${langs[@]+"${langs[@]}"}"; do
         if [[ -d "$SCRIPT_DIR/rules/$lang" ]]; then
             if $DRY_RUN; then
                 info "Would copy: rules/$lang/ -> $CLAUDE_DIR/rules/$lang/"
@@ -1299,7 +1302,7 @@ install_rules() {
         local known_langs=("python" "typescript" "golang")
         for known in "${known_langs[@]}"; do
             local keep=false
-            for lang in "${langs[@]}"; do
+            for lang in "${langs[@]+"${langs[@]}"}"; do
                 if [[ "$lang" == "$known" ]]; then
                     keep=true
                     break


### PR DESCRIPTION
`install_rules` aborts on macOS (default `/bin/bash` 3.2.57) when a user runs a selective install that picks rules-common without any language rules. Under `set -euo pipefail`, `"${langs[@]}"` on an empty array trips "unbound variable" and exits the installer right after "Common rules installed", so install_skills / install_plugins / install_lessons / install_statusline / install_mcp / install_plugins / install_deepxiv all silently never run.

Use the `"${arr[@]+"${arr[@]}"}"` expansion at the two `langs` iteration sites so the empty case expands to nothing instead of aborting.

Repro (bash 3.2):

    set -euo pipefail
    langs=()
    for x in "${langs[@]}"; do :; done   # langs[@]: unbound variable

This matches the guard style already used elsewhere (e.g. SELECTED_SKILLS at install.sh:1340 and SELECTED_DEEPXIV_SKILLS at install.sh:1388).

Closes #37