### PR TITLE
docs: add Cursor branch link to README navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <!-- This is the source of truth. README.zh-CN.md is the Chinese translation. Keep both in sync. -->
 
-**English** | [中文](./README.zh-CN.md) | [Codex Branch](https://github.com/Mizoreww/awesome-claude-code-config/tree/codex) | [Changelog](./CHANGELOG.md)
+**English** | [中文](./README.zh-CN.md) | [Codex Branch](https://github.com/Mizoreww/awesome-claude-code-config/tree/codex) | [Cursor Branch](https://github.com/Mizoreww/awesome-claude-code-config/tree/cursor) | [Changelog](./CHANGELOG.md)
 
 # Awesome Claude Code Configuration
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,6 +1,6 @@
 <!-- 本文件与 README.md 同步维护。README.md 为主，本文件为翻译。 -->
 
-[English](./README.md) | **中文** | [Codex 分支](https://github.com/Mizoreww/awesome-claude-code-config/tree/codex) | [更新日志](./CHANGELOG.zh-CN.md)
+[English](./README.md) | **中文** | [Codex 分支](https://github.com/Mizoreww/awesome-claude-code-config/tree/codex) | [Cursor 分支](https://github.com/Mizoreww/awesome-claude-code-config/tree/cursor) | [更新日志](./CHANGELOG.zh-CN.md)
 
 # Awesome Claude Code Configuration
 


### PR DESCRIPTION
## Summary
- Add a **Cursor Branch** link to the README nav row (English + 中文), next to the existing **Codex Branch** link, so the `cursor` branch is discoverable from `main`.

This complements #44 (the `cursor` branch). The nav link targets `…/tree/cursor`, which resolves once that branch lands upstream.

## Test plan
- [x] Nav row renders with the new link in both `README.md` and `README.zh-CN.md`
- [x] Only the two nav lines change (`git diff --stat`: 2 files, +2/-2)

Made with [Cursor](https://cursor.com)