### PR TITLE
Fix Matt Pocock v1.1 skill installation and migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 - Upgraded the managed Matt Pocock workflow set to v1.1.0: `to-prd`/`to-issues` are replaced by `to-spec`/`to-tickets`, `wayfinder` is added, and the retired `decision-mapping`/`review` names are migration-only cleanup entries.
-- Made Matt Pocock installs reproducible in both Bash and PowerShell by downloading release commit `d574778f94cf620fcc8ce741584093bc650a61d3` and installing from the local snapshot; added per-skill content verification, explicit retirement of matching current and legacy lock entries, provenance-gated cleanup across shared agent associations, and fail-closed ownership handling.
+- Made Matt Pocock installs reproducible in both Bash and PowerShell by downloading release commit `d574778f94cf620fcc8ce741584093bc650a61d3` and installing from the local snapshot; added per-skill content verification, CLI-compatible home/XDG lock discovery, explicit retirement of matching current and legacy lock entries, provenance-gated cleanup across shared agent associations, and fail-closed ownership handling.
 - Migrated the latest Claude main installer categories into the Codex branch as Codex-native groups: Review, Workflow, Development Tools, Design & Content, Lifestyle, Academic Research, Slides, and MCP Servers.
 - Added `npx skills@latest add ... --agent codex --copy --yes --full-depth` as the first-choice installer path for compatible upstream skill packs, with the Python `skill-installer` kept as fallback for path-based packs.
 - Set the Codex template defaults to `model = "gpt-5.6-sol"`, `model_reasoning_effort = "max"`, `approval_policy = "never"`, `sandbox_mode = "danger-full-access"`, and a `[tui].status_line` footer showing model, reasoning, project, branch, context use, five-hour quota, and weekly quota.
@@ -20,7 +20,7 @@
 
 ### Design Rationale
 - A successful `skills@latest` exit does not prove that every requested name was installed, and remote tag/commit suffixes currently resolve inconsistently. A prevalidated immutable local snapshot plus explicit directory checks prevents partial or mixed-version installs.
-- Omitting `--agent` is the current reliable all-agent removal path: `skills@1.5.16` rejects its documented `--agent '*'` value. Explicit matching-source lock cleanup also covers retired entries that no longer have an installed directory for the CLI to discover.
+- Omitting `--agent` is the current reliable all-agent removal path: `skills@1.5.16` rejects its documented `--agent '*'` value. Explicit matching-source lock cleanup also covers retired entries that no longer have an installed directory for the CLI to discover, and mirrors the CLI's `$XDG_STATE_HOME/skills/.skill-lock.json` override when configured.
 - Codex does not have Claude Code's plugin runtime, so the migration preserves user-facing categories while mapping installable capabilities to Codex skills, MCP servers, or explicit skipped items.
 - `npx skills` is the most direct cross-agent skill installer for repositories that expose valid `SKILL.md` entries, while the existing Python installer remains useful as a fallback for nested path installs.
 - Codex's `/statusline` command persists footer fields under `[tui]`; writing a top-level `status_line` can silently land inside the previous TOML table when appended to an existing config.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased] - 2026-07-10
 
 ### Features
+- Upgraded the managed Matt Pocock workflow set to v1.1.0: `to-prd`/`to-issues` are replaced by `to-spec`/`to-tickets`, `wayfinder` is added, and the retired `decision-mapping`/`review` names are migration-only cleanup entries.
+- Made Matt Pocock installs reproducible in both Bash and PowerShell by downloading release commit `d574778f94cf620fcc8ce741584093bc650a61d3` and installing from the local snapshot; added per-skill content verification, retirement of matching remote lock entries, and provenance-gated cleanup across shared agent associations.
 - Migrated the latest Claude main installer categories into the Codex branch as Codex-native groups: Review, Workflow, Development Tools, Design & Content, Lifestyle, Academic Research, Slides, and MCP Servers.
 - Added `npx skills@latest add ... --agent codex --copy --yes --full-depth` as the first-choice installer path for compatible upstream skill packs, with the Python `skill-installer` kept as fallback for path-based packs.
 - Set the Codex template defaults to `model = "gpt-5.6-sol"`, `model_reasoning_effort = "max"`, `approval_policy = "never"`, `sandbox_mode = "danger-full-access"`, and a `[tui].status_line` footer showing model, reasoning, project, branch, context use, five-hour quota, and weekly quota.
@@ -17,15 +19,17 @@
 - Made Playwright MCP runtime-safe across both installers and the static `config.toml` template: pin `@playwright/mcp@0.0.78`, use an isolated Node.js 24 launcher when the host Node.js is older than 20, and refuse to register the server unless it returns an MCP `initialize` result.
 
 ### Design Rationale
+- A successful `skills@latest` exit does not prove that every requested name was installed, and remote tag/commit suffixes currently resolve inconsistently. A prevalidated immutable local snapshot plus explicit directory checks prevents partial or mixed-version installs.
 - Codex does not have Claude Code's plugin runtime, so the migration preserves user-facing categories while mapping installable capabilities to Codex skills, MCP servers, or explicit skipped items.
 - `npx skills` is the most direct cross-agent skill installer for repositories that expose valid `SKILL.md` entries, while the existing Python installer remains useful as a fallback for nested path installs.
 - Codex's `/statusline` command persists footer fields under `[tui]`; writing a top-level `status_line` can silently land inside the previous TOML table when appended to an existing config.
 - The Codex installer now favors a clean selectable surface over migration parity for items that would only warn or require heavy manual setup.
-- A validated ownership file bounds reconciliation so a generic catalogue name is never treated as deletion authority by itself. `npx skills remove --global --agent codex` updates Codex/global metadata before Codex-local fallback cleanup, and generic `~/.agents/skills` children are never scanned or deleted.
+- A validated ownership file bounds reconciliation so a generic catalogue name is never treated as deletion authority by itself. `npx skills remove --global --agent codex` updates Codex/global metadata before Codex-local fallback cleanup, and generic `~/.agents/skills` children are never scanned or deleted except by an explicit provenance-verified retired-source migration.
 - Current `skills@latest` global Codex installs can use the canonical shared `~/.agents/skills` directory even with `--agent codex --copy`; Codex discovers that directory, while its root `/` menu remains a command menu and exposes installed skills through `/skills` or `@`.
 - `codex mcp add` proves that configuration was written, not that the stdio process can initialize. Sending the exact launcher a JSON-RPC `initialize` request first prevents an incompatible Node.js/Playwright combination from being reported as a successful install, while pinning the MCP version prevents a later `latest` release from silently changing a validated command.
 
 ### Notes & Caveats
+- Matt Pocock legacy cleanup removes all agent associations only when installer ownership or a matching `mattpocock/skills` lock source proves provenance; unknown same-name skills are preserved.
 - `github` and `lark-mcp` remain credential-gated; GitHub uses `GITHUB_PERSONAL_ACCESS_TOKEN`, while lark-mcp stays manual because it needs app credentials.
 - The Slides group currently installs `frontend-slides` only; `ppt-master` is intentionally omitted because its setup path is too heavy for this installer.
 - The autonomous YOLO defaults should only be used in trusted repositories.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 - Upgraded the managed Matt Pocock workflow set to v1.1.0: `to-prd`/`to-issues` are replaced by `to-spec`/`to-tickets`, `wayfinder` is added, and the retired `decision-mapping`/`review` names are migration-only cleanup entries.
-- Made Matt Pocock installs reproducible in both Bash and PowerShell by downloading release commit `d574778f94cf620fcc8ce741584093bc650a61d3` and installing from the local snapshot; added per-skill content verification, retirement of matching remote lock entries, and provenance-gated cleanup across shared agent associations.
+- Made Matt Pocock installs reproducible in both Bash and PowerShell by downloading release commit `d574778f94cf620fcc8ce741584093bc650a61d3` and installing from the local snapshot; added per-skill content verification, explicit retirement of matching current and legacy lock entries, provenance-gated cleanup across shared agent associations, and fail-closed ownership handling.
 - Migrated the latest Claude main installer categories into the Codex branch as Codex-native groups: Review, Workflow, Development Tools, Design & Content, Lifestyle, Academic Research, Slides, and MCP Servers.
 - Added `npx skills@latest add ... --agent codex --copy --yes --full-depth` as the first-choice installer path for compatible upstream skill packs, with the Python `skill-installer` kept as fallback for path-based packs.
 - Set the Codex template defaults to `model = "gpt-5.6-sol"`, `model_reasoning_effort = "max"`, `approval_policy = "never"`, `sandbox_mode = "danger-full-access"`, and a `[tui].status_line` footer showing model, reasoning, project, branch, context use, five-hour quota, and weekly quota.
@@ -20,6 +20,7 @@
 
 ### Design Rationale
 - A successful `skills@latest` exit does not prove that every requested name was installed, and remote tag/commit suffixes currently resolve inconsistently. A prevalidated immutable local snapshot plus explicit directory checks prevents partial or mixed-version installs.
+- Omitting `--agent` is the current reliable all-agent removal path: `skills@1.5.16` rejects its documented `--agent '*'` value. Explicit matching-source lock cleanup also covers retired entries that no longer have an installed directory for the CLI to discover.
 - Codex does not have Claude Code's plugin runtime, so the migration preserves user-facing categories while mapping installable capabilities to Codex skills, MCP servers, or explicit skipped items.
 - `npx skills` is the most direct cross-agent skill installer for repositories that expose valid `SKILL.md` entries, while the existing Python installer remains useful as a fallback for nested path installs.
 - Codex's `/statusline` command persists footer fields under `[tui]`; writing a top-level `status_line` can silently land inside the previous TOML table when appended to an existing config.
@@ -29,7 +30,7 @@
 - `codex mcp add` proves that configuration was written, not that the stdio process can initialize. Sending the exact launcher a JSON-RPC `initialize` request first prevents an incompatible Node.js/Playwright combination from being reported as a successful install, while pinning the MCP version prevents a later `latest` release from silently changing a validated command.
 
 ### Notes & Caveats
-- Matt Pocock legacy cleanup removes all agent associations only when installer ownership or a matching `mattpocock/skills` lock source proves provenance; unknown same-name skills are preserved.
+- Matt Pocock legacy cleanup removes all agent associations and matching-source lock entries only when installer ownership or a `mattpocock/skills` lock source proves provenance; unknown same-name skills and unrelated lock entries are preserved.
 - `github` and `lark-mcp` remain credential-gated; GitHub uses `GITHUB_PERSONAL_ACCESS_TOKEN`, while lark-mcp stays manual because it needs app credentials.
 - The Slides group currently installs `frontend-slides` only; `ppt-master` is intentionally omitted because its setup path is too heavy for this installer.
 - The autonomous YOLO defaults should only be used in trusted repositories.

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -3,6 +3,8 @@
 ## [Unreleased] - 2026-07-10
 
 ### 新功能
+- 托管的 Matt Pocock 工作流升级到 v1.1.0：用 `to-spec`/`to-tickets` 替换 `to-prd`/`to-issues`，新增 `wayfinder`，并把已退役的 `decision-mapping`/`review` 降为仅迁移清理项。
+- Bash 与 PowerShell 都会下载 release commit `d574778f94cf620fcc8ce741584093bc650a61d3` 的本地快照来实现可复现安装；新增逐 skill 内容验证、匹配远程 lock 条目退役，以及基于来源校验的共享 agent 关联清理。
 - 将 Claude main 的最新安装分类迁移到 Codex 分支，并用 Codex-native 分组呈现：Review、Workflow、Development Tools、Design & Content、Lifestyle、Academic Research、Slides、MCP Servers。
 - 对兼容的上游 skill 包优先使用 `npx skills@latest add ... --agent codex --copy --yes --full-depth` 安装；按路径安装的包仍保留 Python `skill-installer` 作为 fallback。
 - Codex 模板默认设置为 `model = "gpt-5.6-sol"`、`model_reasoning_effort = "max"`、`approval_policy = "never"`、`sandbox_mode = "danger-full-access"`；`[tui].status_line` 统一显示模型、推理强度、项目、分支、上下文用量、5 小时配额和每周配额。
@@ -17,15 +19,17 @@
 - Bash、PowerShell 安装器与静态 `config.toml` 模板现在都能安全启动 Playwright MCP：固定 `@playwright/mcp@0.0.78`，主机 Node.js 低于 20 时使用隔离的 Node.js 24 launcher，并在 MCP `initialize` 没有返回结果时拒绝写入坏配置。
 
 ### 设计理由
+- `skills@latest` 返回成功并不代表每个请求名称都已安装，而且远程 tag/commit 后缀当前可能解析不一致。预验证的不可变本地快照配合显式目录检查，可以阻止部分安装和混合版本。
 - Codex 没有 Claude Code 的同款 plugin runtime，所以迁移目标是保留用户可识别的分类，同时把能力映射到 Codex skills、MCP server 或明确跳过的项目。
 - `npx skills` 是安装包含有效 `SKILL.md` 的跨 agent skill 仓库的直接路径；既有 Python installer 继续作为嵌套路径安装的回退方案。
 - Codex 的 `/statusline` 会把 footer 字段保存到 `[tui]`；把 `status_line` 追加到顶层可能因为 TOML table 作用域而悄悄落进前一个表。
 - Codex 安装器现在优先保持可选项干净；只会警告或需要很重手动配置的项目不再为了迁移对齐而展示。
-- 清理范围受经过校验的 ownership 文件约束，目录名本身不再代表删除权限。安装器先通过 `npx skills remove --global --agent codex` 更新 Codex/全局元数据，再只对 Codex 本地目录做 fallback 清理；不会扫描或删除普通的 `~/.agents/skills` 子目录。
+- 清理范围受经过校验的 ownership 文件约束，目录名本身不再代表删除权限。安装器先通过 `npx skills remove --global --agent codex` 更新 Codex/全局元数据，再只对 Codex 本地目录做 fallback 清理；除显式且来源已验证的退役项迁移外，不会扫描或删除普通的 `~/.agents/skills` 子目录。
 - 当前 `skills@latest` 即使指定 `--agent codex --copy`，全局 Codex skill 也可能安装到规范化的共享目录 `~/.agents/skills`；Codex 会发现该目录，而根 `/` 菜单仍是命令菜单，已安装 skills 通过 `/skills` 或 `@` 进入。
 - `codex mcp add` 只能证明配置已写入，不能证明 stdio 进程能完成初始化。安装前向实际 launcher 发送 JSON-RPC `initialize` 请求，可以阻止不兼容的 Node.js/Playwright 组合被误报为成功；固定 MCP 版本则避免后续 `latest` 发布悄悄改变已验证命令。
 
 ### 注意事项
+- Matt Pocock 旧名称只有在 installer ownership 或匹配的 `mattpocock/skills` lock 来源证明其归属时，才会移除全部 agent 关联；来源不明的同名自定义 skill 会被保留。
 - `github` 和 `lark-mcp` 仍需要真实凭据；GitHub 使用 `GITHUB_PERSONAL_ACCESS_TOKEN`，lark-mcp 因需要 app credentials 仍保持手动配置。
 - Slides 分组目前只安装 `frontend-slides`；`ppt-master` 因安装路径过重，已从该安装器移除。
 - YOLO 自主默认值只适合可信仓库。

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -4,7 +4,7 @@
 
 ### 新功能
 - 托管的 Matt Pocock 工作流升级到 v1.1.0：用 `to-spec`/`to-tickets` 替换 `to-prd`/`to-issues`，新增 `wayfinder`，并把已退役的 `decision-mapping`/`review` 降为仅迁移清理项。
-- Bash 与 PowerShell 都会下载 release commit `d574778f94cf620fcc8ce741584093bc650a61d3` 的本地快照来实现可复现安装；新增逐 skill 内容验证、当前及旧名称匹配 lock 的显式退役、基于来源校验的共享 agent 关联清理，以及失败时 fail-closed 的 ownership 处理。
+- Bash 与 PowerShell 都会下载 release commit `d574778f94cf620fcc8ce741584093bc650a61d3` 的本地快照来实现可复现安装；新增逐 skill 内容验证、与 CLI 一致的 home/XDG lock 查找、当前及旧名称匹配 lock 的显式退役、基于来源校验的共享 agent 关联清理，以及失败时 fail-closed 的 ownership 处理。
 - 将 Claude main 的最新安装分类迁移到 Codex 分支，并用 Codex-native 分组呈现：Review、Workflow、Development Tools、Design & Content、Lifestyle、Academic Research、Slides、MCP Servers。
 - 对兼容的上游 skill 包优先使用 `npx skills@latest add ... --agent codex --copy --yes --full-depth` 安装；按路径安装的包仍保留 Python `skill-installer` 作为 fallback。
 - Codex 模板默认设置为 `model = "gpt-5.6-sol"`、`model_reasoning_effort = "max"`、`approval_policy = "never"`、`sandbox_mode = "danger-full-access"`；`[tui].status_line` 统一显示模型、推理强度、项目、分支、上下文用量、5 小时配额和每周配额。
@@ -20,7 +20,7 @@
 
 ### 设计理由
 - `skills@latest` 返回成功并不代表每个请求名称都已安装，而且远程 tag/commit 后缀当前可能解析不一致。预验证的不可变本地快照配合显式目录检查，可以阻止部分安装和混合版本。
-- 省略 `--agent` 是当前可靠的全 agent 删除路径：`skills@1.5.16` 会拒绝文档中的 `--agent '*'`。显式清理来源匹配的 lock，还能覆盖已经没有安装目录、CLI 无法发现的退役条目。
+- 省略 `--agent` 是当前可靠的全 agent 删除路径：`skills@1.5.16` 会拒绝文档中的 `--agent '*'`。显式清理来源匹配的 lock，还能覆盖已经没有安装目录、CLI 无法发现的退役条目；配置了 XDG 时则与 CLI 一样使用 `$XDG_STATE_HOME/skills/.skill-lock.json`。
 - Codex 没有 Claude Code 的同款 plugin runtime，所以迁移目标是保留用户可识别的分类，同时把能力映射到 Codex skills、MCP server 或明确跳过的项目。
 - `npx skills` 是安装包含有效 `SKILL.md` 的跨 agent skill 仓库的直接路径；既有 Python installer 继续作为嵌套路径安装的回退方案。
 - Codex 的 `/statusline` 会把 footer 字段保存到 `[tui]`；把 `status_line` 追加到顶层可能因为 TOML table 作用域而悄悄落进前一个表。

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -4,7 +4,7 @@
 
 ### 新功能
 - 托管的 Matt Pocock 工作流升级到 v1.1.0：用 `to-spec`/`to-tickets` 替换 `to-prd`/`to-issues`，新增 `wayfinder`，并把已退役的 `decision-mapping`/`review` 降为仅迁移清理项。
-- Bash 与 PowerShell 都会下载 release commit `d574778f94cf620fcc8ce741584093bc650a61d3` 的本地快照来实现可复现安装；新增逐 skill 内容验证、匹配远程 lock 条目退役，以及基于来源校验的共享 agent 关联清理。
+- Bash 与 PowerShell 都会下载 release commit `d574778f94cf620fcc8ce741584093bc650a61d3` 的本地快照来实现可复现安装；新增逐 skill 内容验证、当前及旧名称匹配 lock 的显式退役、基于来源校验的共享 agent 关联清理，以及失败时 fail-closed 的 ownership 处理。
 - 将 Claude main 的最新安装分类迁移到 Codex 分支，并用 Codex-native 分组呈现：Review、Workflow、Development Tools、Design & Content、Lifestyle、Academic Research、Slides、MCP Servers。
 - 对兼容的上游 skill 包优先使用 `npx skills@latest add ... --agent codex --copy --yes --full-depth` 安装；按路径安装的包仍保留 Python `skill-installer` 作为 fallback。
 - Codex 模板默认设置为 `model = "gpt-5.6-sol"`、`model_reasoning_effort = "max"`、`approval_policy = "never"`、`sandbox_mode = "danger-full-access"`；`[tui].status_line` 统一显示模型、推理强度、项目、分支、上下文用量、5 小时配额和每周配额。
@@ -20,6 +20,7 @@
 
 ### 设计理由
 - `skills@latest` 返回成功并不代表每个请求名称都已安装，而且远程 tag/commit 后缀当前可能解析不一致。预验证的不可变本地快照配合显式目录检查，可以阻止部分安装和混合版本。
+- 省略 `--agent` 是当前可靠的全 agent 删除路径：`skills@1.5.16` 会拒绝文档中的 `--agent '*'`。显式清理来源匹配的 lock，还能覆盖已经没有安装目录、CLI 无法发现的退役条目。
 - Codex 没有 Claude Code 的同款 plugin runtime，所以迁移目标是保留用户可识别的分类，同时把能力映射到 Codex skills、MCP server 或明确跳过的项目。
 - `npx skills` 是安装包含有效 `SKILL.md` 的跨 agent skill 仓库的直接路径；既有 Python installer 继续作为嵌套路径安装的回退方案。
 - Codex 的 `/statusline` 会把 footer 字段保存到 `[tui]`；把 `status_line` 追加到顶层可能因为 TOML table 作用域而悄悄落进前一个表。
@@ -29,7 +30,7 @@
 - `codex mcp add` 只能证明配置已写入，不能证明 stdio 进程能完成初始化。安装前向实际 launcher 发送 JSON-RPC `initialize` 请求，可以阻止不兼容的 Node.js/Playwright 组合被误报为成功；固定 MCP 版本则避免后续 `latest` 发布悄悄改变已验证命令。
 
 ### 注意事项
-- Matt Pocock 旧名称只有在 installer ownership 或匹配的 `mattpocock/skills` lock 来源证明其归属时，才会移除全部 agent 关联；来源不明的同名自定义 skill 会被保留。
+- Matt Pocock 旧名称只有在 installer ownership 或 `mattpocock/skills` lock 来源证明其归属时，才会移除全部 agent 关联和来源匹配的 lock；来源不明的同名自定义 skill 与无关 lock 条目都会保留。
 - `github` 和 `lark-mcp` 仍需要真实凭据；GitHub 使用 `GITHUB_PERSONAL_ACCESS_TOKEN`，lark-mcp 因需要 app credentials 仍保持手动配置。
 - Slides 分组目前只安装 `frontend-slides`；`ppt-master` 因安装路径过重，已从该安装器移除。
 - YOLO 自主默认值只适合可信仓库。

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ This keeps common principles and language-specific practices aligned.
 
 | Skill Set | Source | Coverage |
 |----------|--------|----------|
-| mattpocock/skills | [mattpocock/skills](https://github.com/mattpocock/skills) | `ask-matt`, grilling/design, research, PRD/issues, implementation, triage, TDD, architecture and domain-modeling workflows via `npx skills` |
+| mattpocock/skills | [mattpocock/skills](https://github.com/mattpocock/skills) | Pinned v1.1 workflows for `ask-matt`, grilling/design, research, specs/tickets, wayfinding, implementation, triage, TDD, architecture and domain modeling |
 | superpowers | [obra/superpowers](https://github.com/obra/superpowers) | full native superpowers set, including brainstorming, plan execution, review handoff, worktrees; installed via `npx skills` with git/junction fallback |
 | andrej-karpathy-skills | [forrestchang/andrej-karpathy-skills](https://github.com/forrestchang/andrej-karpathy-skills) | Karpathy-style coding guidelines via `npx skills` |
 | anthropic skills packs | [anthropics/skills](https://github.com/anthropics/skills) | document tools, frontend design, canvas/art, MCP builder |
@@ -153,6 +153,8 @@ Remote skills are installed with:
 ```bash
 npx -y skills@latest add <repo> --global --agent codex --copy --yes --full-depth --skill <name>
 ```
+
+Matt Pocock skills are the exception: both installers download the immutable v1.1.0 release commit first, then pass that local snapshot to `skills@latest`. This avoids mutable `main` content and the current CLI's unreliable handling of remote tag/commit suffixes. Installation succeeds only when every requested skill directory matches the snapshot; matching remote lock entries are retired so a later generic `skills update` cannot overwrite the pinned content. Provenance-verified retired names (`to-prd`, `to-issues`, `decision-mapping`, `review`) are removed across shared agent associations during migration.
 
 After `mattpocock/skills` installs successfully, the installer prints a 30-second Codex quickstart. With the current `skills` CLI, global Codex installs may use the shared `~/.agents/skills` directory even when `--agent codex --copy` is set; Codex discovers those skills directly. In Codex, type `/skills` and choose **List skills**, or press `@`, then search for `setup-matt-pocock-skills`. Installed skills are not separate root slash commands such as `/setup-matt-pocock-skills`.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -139,7 +139,7 @@ skills/rules  → python-patterns、golang-patterns、frontend-patterns
 
 | 技能集 | 来源 | 覆盖范围 |
 |-------|------|----------|
-| mattpocock/skills | [mattpocock/skills](https://github.com/mattpocock/skills) | 通过 `npx skills` 安装 `ask-matt`、grilling/design、research、PRD/issues、implementation、triage、TDD、架构和领域建模工作流 |
+| mattpocock/skills | [mattpocock/skills](https://github.com/mattpocock/skills) | 固定 v1.1 的 `ask-matt`、grilling/design、research、specs/tickets、wayfinding、implementation、triage、TDD、架构和领域建模工作流 |
 | superpowers | [obra/superpowers](https://github.com/obra/superpowers) | 完整原生 superpowers 集合，含 brainstorming、计划执行、review handoff、worktree 等；优先通过 `npx skills` 安装，失败时回退到 git/junction |
 | andrej-karpathy-skills | [forrestchang/andrej-karpathy-skills](https://github.com/forrestchang/andrej-karpathy-skills) | 通过 `npx skills` 安装 Karpathy 风格编码指南 |
 | anthropic skills packs | [anthropics/skills](https://github.com/anthropics/skills) | 文档处理、前端设计、画布/艺术、MCP builder |
@@ -153,6 +153,8 @@ skills/rules  → python-patterns、golang-patterns、frontend-patterns
 ```bash
 npx -y skills@latest add <repo> --global --agent codex --copy --yes --full-depth --skill <name>
 ```
+
+Matt Pocock skills 是例外：两个安装器都会先下载不可变的 v1.1.0 release commit，再把该本地快照交给 `skills@latest`。这样可以避开可变的 `main` 内容，以及当前 CLI 对远程 tag/commit 后缀处理不可靠的问题。只有全部请求的 skill 目录与快照一致时才算安装成功；匹配的远程 lock 条目会被移除，避免之后的通用 `skills update` 覆盖固定内容。迁移时还会跨共享 agent 关联移除来源已验证的旧名称（`to-prd`、`to-issues`、`decision-mapping`、`review`）。
 
 `mattpocock/skills` 安装成功后，安装器会显示一段 30 秒 Codex Quickstart。当前版本的 `skills` CLI 即使指定 `--agent codex --copy`，全局 Codex skill 也可能放在共享目录 `~/.agents/skills`，Codex 会直接发现它们。在 Codex 中输入 `/skills` 并选择 **List skills**，或直接按 `@`，然后搜索 `setup-matt-pocock-skills`。已安装的 skill 不会变成 `/setup-matt-pocock-skills` 这样的根级 slash command。
 

--- a/docs/testing/matt-pocock-v1.1-migration.tdd.md
+++ b/docs/testing/matt-pocock-v1.1-migration.tdd.md
@@ -1,0 +1,47 @@
+# Matt Pocock v1.1 Migration TDD Evidence
+
+Date: 2026-07-13
+
+Branch: PR #49, `fix/matt-skills-v1-1-migration`
+
+Source plan: the review task supplied the user journey and acceptance criteria; no standalone plan file was provided.
+
+## User journeys
+
+- As an existing installer user, I want retired Matt Pocock skills removed from every shared agent association so the v1.1 install can proceed.
+- As a user with a stale Matt Pocock lock entry but no remaining skill directory, I want the matching lock retired so a later generic update cannot restore retired content.
+- As a PowerShell user, I want every failed pinned install to clear ownership recorded during the attempt so unverified content is never treated as installer-owned.
+- As a maintainer, I want the same migration guarantees executed by both Bash and PowerShell tests.
+
+## RED and GREEN evidence
+
+| Stage | Commit | Command | Result | Evidence |
+|---|---|---|---|---|
+| RED | `ffd06d5` | `bash tests/check_codex_skill_reconciliation.sh` | Expected failure | `skills@latest remove ... --agent '*'` was rejected and the test ended with `legacy Matt Pocock cleanup failed`. |
+| RED | `ffd06d5` | `/tmp/pr49-pwsh/runtime/pwsh -NoProfile -File tests/install_ps1_skill_reconciliation.Tests.ps1` | Expected failure | After making the fixture cross-platform, PowerShell reached the same legacy-cleanup failure. |
+| GREEN | `225a7c4` | `bash tests/check_codex_skill_reconciliation.sh` | PASS | Output ended with `Codex skill reconciliation checks passed`. |
+| GREEN | `225a7c4` | `/tmp/pr49-pwsh/runtime/pwsh -NoProfile -File tests/install_ps1_skill_reconciliation.Tests.ps1` | PASS | Output: `install.ps1 skill reconciliation tests passed`. |
+
+## Test specification
+
+| # | What is guaranteed | Test target | Type | Result |
+|---|---|---|---|---|
+| 1 | Legacy cleanup omits the invalid wildcard agent and uses the CLI's default all-agent removal path | Bash and PowerShell npx fakes | Integration/regression | PASS |
+| 2 | Matching `mattpocock/skills` lock entries for retired names are deleted while unrelated lock entries remain unchanged | legacy cleanup fixtures | Integration/error state | PASS |
+| 3 | A PowerShell exception after npx records ownership returns failure and clears ownership for every requested skill | injected lock-cleanup exception | Unit/error path | PASS |
+| 4 | The PowerShell reconciliation fixture initializes every selection flag and uses a platform-neutral temporary directory | full PowerShell test script | Cross-platform regression | PASS |
+
+## External CLI reproduction
+
+An isolated HOME with `skills@1.5.16` under Node.js 24 reproduced the upstream behavior directly:
+
+- `skills remove to-prd --global --agent '*' --yes` exited 1 with `Invalid agents: *` and preserved the skill.
+- `skills remove to-prd --global --yes` exited 0 and removed the skill from the detected agents.
+
+## Coverage and known gaps
+
+This repository has no line-coverage harness for shell installers. The focused tests execute the affected functions and success/error branches in both implementations. PowerShell 7.6.3 was downloaded to a temporary directory from the official Microsoft release, verified against its published SHA-256, and used without a system installation. Native Windows PowerShell 5.1 remains a Windows CI/manual compatibility gate.
+
+## Merge evidence
+
+The RED and GREEN checkpoints are separate commits on the PR branch. Preserve this document or the equivalent command/result summary if the commits are later squashed.

--- a/docs/testing/matt-pocock-v1.1-migration.tdd.md
+++ b/docs/testing/matt-pocock-v1.1-migration.tdd.md
@@ -11,6 +11,7 @@ Source plan: the review task supplied the user journey and acceptance criteria; 
 - As an existing installer user, I want retired Matt Pocock skills removed from every shared agent association so the v1.1 install can proceed.
 - As a user with a stale Matt Pocock lock entry but no remaining skill directory, I want the matching lock retired so a later generic update cannot restore retired content.
 - As a PowerShell user, I want every failed pinned install to clear ownership recorded during the attempt so unverified content is never treated as installer-owned.
+- As a user with `XDG_STATE_HOME`, I want the installer to read and retire the same global skill lock that the Skills CLI updates.
 - As a maintainer, I want the same migration guarantees executed by both Bash and PowerShell tests.
 
 ## RED and GREEN evidence
@@ -21,6 +22,10 @@ Source plan: the review task supplied the user journey and acceptance criteria; 
 | RED | `ffd06d5` | `/tmp/pr49-pwsh/runtime/pwsh -NoProfile -File tests/install_ps1_skill_reconciliation.Tests.ps1` | Expected failure | After making the fixture cross-platform, PowerShell reached the same legacy-cleanup failure. |
 | GREEN | `225a7c4` | `bash tests/check_codex_skill_reconciliation.sh` | PASS | Output ended with `Codex skill reconciliation checks passed`. |
 | GREEN | `225a7c4` | `/tmp/pr49-pwsh/runtime/pwsh -NoProfile -File tests/install_ps1_skill_reconciliation.Tests.ps1` | PASS | Output: `install.ps1 skill reconciliation tests passed`. |
+| XDG RED | `a101f90` | `bash tests/check_codex_skill_reconciliation.sh` | Expected failure | Output: `global skill lock path did not honor XDG_STATE_HOME`. |
+| XDG RED | `a101f90` | `bash tests/check_codex_migration.sh` | Expected failure | The Bash/PowerShell parity contract found no XDG lock-path handling in the installers. |
+| XDG GREEN | `fabd70c` | `bash tests/check_codex_migration.sh && bash tests/check_codex_skill_reconciliation.sh` | PASS | Both migration and XDG-backed runtime lock scenarios passed. |
+| XDG GREEN | `fabd70c` | `/tmp/pr49-pwsh/runtime/pwsh -NoProfile -File tests/install_ps1_skill_reconciliation.Tests.ps1` | PASS | PowerShell lock and ownership scenarios passed against an XDG-backed lock path. |
 
 ## Test specification
 
@@ -30,6 +35,7 @@ Source plan: the review task supplied the user journey and acceptance criteria; 
 | 2 | Matching `mattpocock/skills` lock entries for retired names are deleted while unrelated lock entries remain unchanged | legacy cleanup fixtures | Integration/error state | PASS |
 | 3 | A PowerShell exception after npx records ownership returns failure and clears ownership for every requested skill | injected lock-cleanup exception | Unit/error path | PASS |
 | 4 | The PowerShell reconciliation fixture initializes every selection flag and uses a platform-neutral temporary directory | full PowerShell test script | Cross-platform regression | PASS |
+| 5 | Both installers use `$XDG_STATE_HOME/skills/.skill-lock.json` when configured and the home fallback otherwise | migration contract plus XDG-backed fixtures | Cross-platform integration | PASS |
 
 ## External CLI reproduction
 

--- a/docs/testing/matt-pocock-v1.1-migration.tdd.md
+++ b/docs/testing/matt-pocock-v1.1-migration.tdd.md
@@ -26,6 +26,8 @@ Source plan: the review task supplied the user journey and acceptance criteria; 
 | XDG RED | `a101f90` | `bash tests/check_codex_migration.sh` | Expected failure | The Bash/PowerShell parity contract found no XDG lock-path handling in the installers. |
 | XDG GREEN | `fabd70c` | `bash tests/check_codex_migration.sh && bash tests/check_codex_skill_reconciliation.sh` | PASS | Both migration and XDG-backed runtime lock scenarios passed. |
 | XDG GREEN | `fabd70c` | `/tmp/pr49-pwsh/runtime/pwsh -NoProfile -File tests/install_ps1_skill_reconciliation.Tests.ps1` | PASS | PowerShell lock and ownership scenarios passed against an XDG-backed lock path. |
+| Resolver RED | `072437a` | `/tmp/pr49-pwsh/runtime/pwsh -NoProfile -File tests/install_ps1_skill_reconciliation.Tests.ps1` | Expected failure | Production did not expose `Get-GlobalSkillLockFile`, so the XDG/HOME conditions could not be tested directly. |
+| Resolver GREEN | `8570566` | `/tmp/pr49-pwsh/runtime/pwsh -NoProfile -File tests/install_ps1_skill_reconciliation.Tests.ps1 && bash tests/check_codex_migration.sh` | PASS | Tests directly executed the production resolver's XDG and HOME fallback branches; the parity contract also passed. |
 
 ## Test specification
 
@@ -35,7 +37,7 @@ Source plan: the review task supplied the user journey and acceptance criteria; 
 | 2 | Matching `mattpocock/skills` lock entries for retired names are deleted while unrelated lock entries remain unchanged | legacy cleanup fixtures | Integration/error state | PASS |
 | 3 | A PowerShell exception after npx records ownership returns failure and clears ownership for every requested skill | injected lock-cleanup exception | Unit/error path | PASS |
 | 4 | The PowerShell reconciliation fixture initializes every selection flag and uses a platform-neutral temporary directory | full PowerShell test script | Cross-platform regression | PASS |
-| 5 | Both installers use `$XDG_STATE_HOME/skills/.skill-lock.json` when configured and the home fallback otherwise | migration contract plus XDG-backed fixtures | Cross-platform integration | PASS |
+| 5 | Both installers use `$XDG_STATE_HOME/skills/.skill-lock.json` when configured and the home fallback otherwise | Bash runtime fixture plus direct `Get-GlobalSkillLockFile` branch tests | Cross-platform integration/unit | PASS |
 
 ## External CLI reproduction
 

--- a/install.ps1
+++ b/install.ps1
@@ -1784,6 +1784,7 @@ function Install-MattPocockSkillNames {
         }
 
         if (-not (Install-NpxSkillNames $sourceDir.FullName $SkillNames)) {
+            Remove-ManagedSkillOwnership $SkillNames
             return $false
         }
 

--- a/install.ps1
+++ b/install.ps1
@@ -158,7 +158,7 @@ $MANAGED_SKILLS = @(
     "frontend-slides",
     "ask-matt", "diagnosing-bugs", "grill-with-docs", "triage",
     "implement", "improve-codebase-architecture", "setup-matt-pocock-skills", "tdd",
-    "to-issues", "to-prd", "prototype", "domain-modeling", "codebase-design",
+    "to-spec", "to-tickets", "wayfinder", "prototype", "domain-modeling", "codebase-design",
     "grill-me", "grilling", "research", "teach", "writing-great-skills",
     "pua", "pua-en", "pua-ja"
 )
@@ -168,7 +168,11 @@ $LEGACY_CLEANUP_SKILLS = @(
     "security-review", "tdd-workflow", "verification-loop", "api-design", "database-migrations"
 )
 
-$OWNERSHIP_SKILLS = @($MANAGED_SKILLS) + @($LEGACY_CLEANUP_SKILLS)
+$MATTPOCOCK_LEGACY_SKILLS = @(
+    "to-issues", "to-prd", "decision-mapping", "review"
+)
+
+$OWNERSHIP_SKILLS = @($MANAGED_SKILLS) + @($LEGACY_CLEANUP_SKILLS) + @($MATTPOCOCK_LEGACY_SKILLS)
 
 $LEGACY_SUPERPOWERS_SKILLS = @(
     "using-superpowers",
@@ -180,7 +184,7 @@ $LEGACY_SUPERPOWERS_SKILLS = @(
 $MATTPOCOCK_SKILLS = @(
     "ask-matt", "diagnosing-bugs", "grill-with-docs", "triage",
     "implement", "improve-codebase-architecture", "setup-matt-pocock-skills", "tdd",
-    "to-issues", "to-prd", "prototype", "domain-modeling", "codebase-design",
+    "to-spec", "to-tickets", "wayfinder", "prototype", "domain-modeling", "codebase-design",
     "grill-me", "grilling", "research", "teach", "writing-great-skills"
 )
 
@@ -197,6 +201,8 @@ $GLOBAL_SKILL_LOCK_FILE = Join-Path $HOME ".agents/.skill-lock.json"
 $script:OwnedManagedSkills = New-Object 'System.Collections.Generic.HashSet[string]'
 $script:ManagedSkillOwnershipLoaded = $false
 $script:MattPocockQuickstartReady = $false
+$script:MATTPOCOCK_VERSION = "v1.1.0"
+$script:MATTPOCOCK_COMMIT = "d574778f94cf620fcc8ce741584093bc650a61d3"
 $script:CODEX_STATUS_LINE = 'status_line = ["model", "reasoning", "project-name", "git-branch", "context-used", "five-hour-limit", "weekly-limit"]'
 $script:CODEX_STATUS_LINE_USE_COLORS = 'status_line_use_colors = true'
 $script:PLAYWRIGHT_MCP_VERSION = "0.0.78"
@@ -220,7 +226,7 @@ function Show-MattPocockQuickstart {
         "  Matt Pocock skills are already installed; do not run npx again.",
         "  1. Restart Codex if it was open during installation.",
         "  2. Type /skills (or press @), choose List skills, then search for setup-matt-pocock-skills.",
-        "  3. Insert and run it; it will ask about your issue tracker, triage labels, and docs location.",
+        "  3. Insert and run it; it will configure the issue tracker, triage labels when applicable, and domain docs.",
         "  Note: installed skills are not individual root slash commands such as /setup-matt-pocock-skills."
     )
 }
@@ -714,7 +720,7 @@ function Install-SelectedAgents {
 
 function Install-SelectedRecommendedSkills {
     if ($script:SelectSkillCodeReview) {
-        if (-not (Install-NpxSkillNames "mattpocock/skills" @("code-review"))) {
+        if (-not (Install-MattPocockSkillNames @("code-review"))) {
             Skip-UnsupportedItem "code-review" "npx skills install failed; use Codex /review as the native fallback"
         }
     }
@@ -730,7 +736,7 @@ function Install-SelectedRecommendedSkills {
     }
 
     if ($script:SelectSkillMattPocock) {
-        if (Install-NpxSkillNames "mattpocock/skills" $MATTPOCOCK_SKILLS) {
+        if (Install-MattPocockSkillNames $MATTPOCOCK_SKILLS) {
             $script:MattPocockQuickstartReady = $true
         } else {
             Skip-UnsupportedItem "mattpocock/skills" "npx skills install failed"
@@ -1461,7 +1467,9 @@ function Test-ManagedSkillName {
 function Get-ExpectedSkillSource {
     param([string]$Skill)
 
-    if ($Skill -ceq "code-review" -or (Test-SkillInList $Skill $MATTPOCOCK_SKILLS)) {
+    if ($Skill -ceq "code-review" -or
+        (Test-SkillInList $Skill $MATTPOCOCK_SKILLS) -or
+        (Test-SkillInList $Skill $MATTPOCOCK_LEGACY_SKILLS)) {
         return "mattpocock/skills"
     }
     if ($Skill -ceq "karpathy-guidelines") {
@@ -1653,6 +1661,55 @@ function Confirm-EmptySkillRemoval {
     return (Confirm-Action "Remove $Count previously installer-managed skill(s)?")
 }
 
+function Test-InstalledSkillNames {
+    param([string[]]$SkillNames)
+
+    $missing = @()
+    foreach ($skill in $SkillNames) {
+        $canonicalSkill = Join-Path $AGENTS_SKILLS_DIR "$skill/SKILL.md"
+        $codexSkill = Join-Path $CODEX_DIR "skills/$skill/SKILL.md"
+        if (-not (Test-Path -LiteralPath $canonicalSkill -PathType Leaf) -and
+            -not (Test-Path -LiteralPath $codexSkill -PathType Leaf)) {
+            $missing += $skill
+        }
+    }
+
+    if ($missing.Count -gt 0) {
+        Write-Warn "npx skills returned success but did not install: $($missing -join ', ')"
+        return $false
+    }
+    return $true
+}
+
+function Remove-MattPocockSkillLockEntries {
+    param([string[]]$SkillNames)
+
+    if (-not (Test-Path -LiteralPath $GLOBAL_SKILL_LOCK_FILE -PathType Leaf)) {
+        return $true
+    }
+    try {
+        $lock = Get-Content -LiteralPath $GLOBAL_SKILL_LOCK_FILE -Raw | ConvertFrom-Json
+        foreach ($skill in $SkillNames) {
+            $property = $lock.skills.PSObject.Properties[$skill]
+            if ($property -and $property.Value.source -ceq "mattpocock/skills") {
+                $lock.skills.PSObject.Properties.Remove($skill)
+            }
+        }
+        $tempLock = "$GLOBAL_SKILL_LOCK_FILE.tmp.$PID"
+        $encoding = New-Object System.Text.UTF8Encoding($false)
+        [System.IO.File]::WriteAllText(
+            $tempLock,
+            (($lock | ConvertTo-Json -Depth 20) + [Environment]::NewLine),
+            $encoding
+        )
+        Move-Item -LiteralPath $tempLock -Destination $GLOBAL_SKILL_LOCK_FILE -Force
+        return $true
+    } catch {
+        Remove-Item -LiteralPath "$GLOBAL_SKILL_LOCK_FILE.tmp.$PID" -Force -ErrorAction SilentlyContinue
+        return $false
+    }
+}
+
 function Install-NpxSkillNames {
     param([string]$Repo, [string[]]$SkillNames)
 
@@ -1675,7 +1732,7 @@ function Install-NpxSkillNames {
     try {
         & npx @npxArgs 2>&1 | ForEach-Object { Write-Host $_ }
         $exitCode = $LASTEXITCODE
-        if ($exitCode -eq 0) {
+        if ($exitCode -eq 0 -and (Test-InstalledSkillNames $SkillNames)) {
             Add-ManagedSkillOwnership $SkillNames
             return $true
         }
@@ -1686,6 +1743,74 @@ function Install-NpxSkillNames {
         } else {
             $env:DO_NOT_TRACK = $oldDoNotTrack
         }
+    }
+}
+
+function Install-MattPocockSkillNames {
+    param([string[]]$SkillNames)
+
+    if (-not (Remove-LegacyMattPocockSkills)) {
+        return $false
+    }
+
+    if ($DryRun) {
+        Write-Info "Would install Matt Pocock $($script:MATTPOCOCK_VERSION) from commit $($script:MATTPOCOCK_COMMIT): $($SkillNames -join ', ')"
+        return $true
+    }
+
+    $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ("mattpocock-skills." + [guid]::NewGuid().ToString("N"))
+    $archive = Join-Path $tempDir "source.tar.gz"
+    New-Item -ItemType Directory -Path $tempDir -Force | Out-Null
+
+    try {
+        $archiveUrl = "https://github.com/mattpocock/skills/archive/$($script:MATTPOCOCK_COMMIT).tar.gz"
+        Invoke-WebRequest -Uri $archiveUrl -OutFile $archive -UseBasicParsing
+        tar -xzf $archive -C $tempDir
+        if ($LASTEXITCODE -ne 0) {
+            throw "tar extraction failed with exit code $LASTEXITCODE"
+        }
+
+        $sourceDir = Get-ChildItem -LiteralPath $tempDir -Directory | Select-Object -First 1
+        if (-not $sourceDir) {
+            throw "pinned archive did not contain a repository root"
+        }
+
+        foreach ($skill in $SkillNames) {
+            $matches = @(Get-ChildItem -LiteralPath (Join-Path $sourceDir.FullName "skills") `
+                -Recurse -Filter "SKILL.md" -File | Where-Object { $_.Directory.Name -ceq $skill })
+            if ($matches.Count -eq 0) {
+                throw "pinned archive is missing requested skill: $skill"
+            }
+        }
+
+        if (-not (Install-NpxSkillNames $sourceDir.FullName $SkillNames)) {
+            return $false
+        }
+
+        foreach ($skill in $SkillNames) {
+            $sourceSkill = @(Get-ChildItem -LiteralPath (Join-Path $sourceDir.FullName "skills") `
+                -Recurse -Filter "SKILL.md" -File | Where-Object { $_.Directory.Name -ceq $skill })[0].Directory.FullName
+            $targetSkill = Join-Path $AGENTS_SKILLS_DIR $skill
+            if (-not (Test-Path -LiteralPath $targetSkill -PathType Container)) {
+                $targetSkill = Join-Path $CODEX_DIR "skills/$skill"
+            }
+            if (-not (Test-DirectoryTreeEqual $sourceSkill $targetSkill)) {
+                Write-Warn "Installed Matt Pocock skill does not match pinned snapshot: $skill"
+                Remove-ManagedSkillOwnership $SkillNames
+                return $false
+            }
+        }
+        if (-not (Remove-MattPocockSkillLockEntries $SkillNames)) {
+            Write-Warn "Could not retire remote Matt Pocock lock entries after pinned installation"
+            Remove-ManagedSkillOwnership $SkillNames
+            return $false
+        }
+        return $true
+    } catch {
+        Write-Warn "Could not install Matt Pocock $($script:MATTPOCOCK_VERSION): $($_.Exception.Message)"
+        return $false
+    } finally {
+        Remove-Item -LiteralPath $tempDir -Recurse -Force -ErrorAction SilentlyContinue
     }
 }
 
@@ -1760,6 +1885,69 @@ function Remove-NpxSkillNames {
     }
 }
 
+function Test-LockedSkillSource {
+    param([string]$Skill, [string]$ExpectedSource)
+
+    if (-not (Test-Path -LiteralPath $GLOBAL_SKILL_LOCK_FILE -PathType Leaf)) {
+        return $false
+    }
+    try {
+        $lock = Get-Content -LiteralPath $GLOBAL_SKILL_LOCK_FILE -Raw | ConvertFrom-Json
+        $property = $lock.skills.PSObject.Properties[$Skill]
+        return ($property -and $property.Value.source -ceq $ExpectedSource)
+    } catch {
+        return $false
+    }
+}
+
+function Remove-LegacyMattPocockSkills {
+    Initialize-ManagedSkillOwnership
+
+    $removable = @()
+    foreach ($skill in $MATTPOCOCK_LEGACY_SKILLS) {
+        if ($script:OwnedManagedSkills.Contains($skill) -or
+            (Test-LockedSkillSource $skill "mattpocock/skills")) {
+            $removable += $skill
+        }
+    }
+    if ($removable.Count -eq 0) { return $true }
+
+    if ($DryRun) {
+        Write-Info "Would remove retired Matt Pocock skills from all agent associations: $($removable -join ', ')"
+        return $true
+    }
+
+    if (-not (Get-Command "npx" -ErrorAction SilentlyContinue)) {
+        Write-Warn "npx not found; cannot safely migrate retired Matt Pocock skills: $($removable -join ', ')"
+        return $false
+    }
+
+    $npxArgs = @("-y", "skills@latest", "remove") + $removable + @("--global", "--agent", "*", "--yes")
+    $oldDoNotTrack = $env:DO_NOT_TRACK
+    $env:DO_NOT_TRACK = "1"
+    try {
+        & npx @npxArgs 2>&1 | ForEach-Object { Write-Host $_ }
+        if ($LASTEXITCODE -ne 0) {
+            Write-Warn "npx skills could not migrate retired Matt Pocock skills: $($removable -join ', ')"
+            return $false
+        }
+    } finally {
+        if ($null -eq $oldDoNotTrack) {
+            Remove-Item Env:DO_NOT_TRACK -ErrorAction SilentlyContinue
+        } else {
+            $env:DO_NOT_TRACK = $oldDoNotTrack
+        }
+    }
+
+    foreach ($skill in $removable) {
+        Remove-Item -LiteralPath (Join-Path $AGENTS_SKILLS_DIR $skill) -Recurse -Force -ErrorAction SilentlyContinue
+        Remove-Item -LiteralPath (Join-Path $CODEX_DIR "skills/$skill") -Recurse -Force -ErrorAction SilentlyContinue
+    }
+    Remove-ManagedSkillOwnership $removable
+    Write-Ok "Removed retired Matt Pocock skills: $($removable -join ', ')"
+    return $true
+}
+
 function Remove-SuperpowersFallback {
     if (-not (Test-SuperpowersFallbackOwned)) {
         if ((Test-Path $SUPERPOWERS_LINK) -or (Test-Path $SUPERPOWERS_DIR)) {
@@ -1807,8 +1995,12 @@ function Sync-InteractiveSkills {
     $stale = @()
 
     Initialize-ManagedSkillOwnership
+    if (-not (Remove-LegacyMattPocockSkills)) {
+        Write-Warn "Retired Matt Pocock skills were preserved because migration cleanup failed"
+    }
 
     foreach ($skill in @($script:OwnedManagedSkills)) {
+        if (Test-SkillInList $skill $MATTPOCOCK_LEGACY_SKILLS) { continue }
         if ($desired -contains $skill) { continue }
         $stale += $skill
     }
@@ -2071,7 +2263,7 @@ function Install-Skills {
     Write-Info "Installing skills (group: $SkillGroup)..."
 
     if ($SkillGroup -eq "core" -or $SkillGroup -eq "all") {
-        if (-not (Install-NpxSkillNames "mattpocock/skills" @("code-review"))) {
+        if (-not (Install-MattPocockSkillNames @("code-review"))) {
             Skip-UnsupportedItem "code-review" "npx skills install failed; use Codex /review as the native fallback"
         }
 
@@ -2081,7 +2273,7 @@ function Install-Skills {
 
         Install-Superpowers
 
-        if (Install-NpxSkillNames "mattpocock/skills" $MATTPOCOCK_SKILLS) {
+        if (Install-MattPocockSkillNames $MATTPOCOCK_SKILLS) {
             $script:MattPocockQuickstartReady = $true
         } else {
             Skip-UnsupportedItem "mattpocock/skills" "npx skills install failed"

--- a/install.ps1
+++ b/install.ps1
@@ -61,6 +61,19 @@ param(
 
 $ErrorActionPreference = "Stop"
 
+function Get-GlobalSkillLockFile {
+    param(
+        [string]$HomePath = $HOME,
+        [AllowEmptyString()]
+        [string]$XdgStateHome = $env:XDG_STATE_HOME
+    )
+
+    if ($XdgStateHome) {
+        return (Join-Path $XdgStateHome "skills/.skill-lock.json")
+    }
+    return (Join-Path $HomePath ".agents/.skill-lock.json")
+}
+
 # ============================================================
 # Paths
 # ============================================================
@@ -197,11 +210,7 @@ $SUPERPOWERS_SKILLS = @(
 )
 $LOCAL_MANAGED_SKILLS = @("paper-reading", "humanizer", "humanizer-zh", "handoff", "adversarial-review", "update")
 $MANAGED_SKILLS_STATE_FILE = Join-Path $CODEX_DIR ".awesome-claude-code-config-managed-skills"
-$GLOBAL_SKILL_LOCK_FILE = if ($env:XDG_STATE_HOME) {
-    Join-Path $env:XDG_STATE_HOME "skills/.skill-lock.json"
-} else {
-    Join-Path $HOME ".agents/.skill-lock.json"
-}
+$GLOBAL_SKILL_LOCK_FILE = Get-GlobalSkillLockFile
 $script:OwnedManagedSkills = New-Object 'System.Collections.Generic.HashSet[string]'
 $script:ManagedSkillOwnershipLoaded = $false
 $script:MattPocockQuickstartReady = $false

--- a/install.ps1
+++ b/install.ps1
@@ -197,7 +197,11 @@ $SUPERPOWERS_SKILLS = @(
 )
 $LOCAL_MANAGED_SKILLS = @("paper-reading", "humanizer", "humanizer-zh", "handoff", "adversarial-review", "update")
 $MANAGED_SKILLS_STATE_FILE = Join-Path $CODEX_DIR ".awesome-claude-code-config-managed-skills"
-$GLOBAL_SKILL_LOCK_FILE = Join-Path $HOME ".agents/.skill-lock.json"
+$GLOBAL_SKILL_LOCK_FILE = if ($env:XDG_STATE_HOME) {
+    Join-Path $env:XDG_STATE_HOME "skills/.skill-lock.json"
+} else {
+    Join-Path $HOME ".agents/.skill-lock.json"
+}
 $script:OwnedManagedSkills = New-Object 'System.Collections.Generic.HashSet[string]'
 $script:ManagedSkillOwnershipLoaded = $false
 $script:MattPocockQuickstartReady = $false

--- a/install.ps1
+++ b/install.ps1
@@ -1808,6 +1808,7 @@ function Install-MattPocockSkillNames {
         }
         return $true
     } catch {
+        Remove-ManagedSkillOwnership $SkillNames
         Write-Warn "Could not install Matt Pocock $($script:MATTPOCOCK_VERSION): $($_.Exception.Message)"
         return $false
     } finally {
@@ -1923,7 +1924,9 @@ function Remove-LegacyMattPocockSkills {
         return $false
     }
 
-    $npxArgs = @("-y", "skills@latest", "remove") + $removable + @("--global", "--agent", "*", "--yes")
+    # Omitting --agent targets every detected agent. skills@1.5.16 currently
+    # rejects the documented wildcard value (`--agent '*'`).
+    $npxArgs = @("-y", "skills@latest", "remove") + $removable + @("--global", "--yes")
     $oldDoNotTrack = $env:DO_NOT_TRACK
     $env:DO_NOT_TRACK = "1"
     try {
@@ -1943,6 +1946,10 @@ function Remove-LegacyMattPocockSkills {
     foreach ($skill in $removable) {
         Remove-Item -LiteralPath (Join-Path $AGENTS_SKILLS_DIR $skill) -Recurse -Force -ErrorAction SilentlyContinue
         Remove-Item -LiteralPath (Join-Path $CODEX_DIR "skills/$skill") -Recurse -Force -ErrorAction SilentlyContinue
+    }
+    if (-not (Remove-MattPocockSkillLockEntries $removable)) {
+        Write-Warn "Could not retire matching lock entries for retired Matt Pocock skills: $($removable -join ', ')"
+        return $false
     }
     Remove-ManagedSkillOwnership $removable
     Write-Ok "Removed retired Matt Pocock skills: $($removable -join ', ')"

--- a/install.sh
+++ b/install.sh
@@ -1278,6 +1278,9 @@ install_mattpocock_skill_names() {
 
   local result=0 source_skill target_skill
   install_npx_skill_names "$source_dir" "${skill_names[@]}" || result=$?
+  if [[ "$result" -ne 0 ]]; then
+    remove_managed_skill_ownership "${skill_names[@]}"
+  fi
   if [[ "$result" -eq 0 ]]; then
     for skill in "${skill_names[@]}"; do
       source_skill=$(find "$source_dir/skills" -path "*/$skill/SKILL.md" -type f -print -quit)

--- a/install.sh
+++ b/install.sh
@@ -1376,7 +1376,9 @@ remove_legacy_mattpocock_skills() {
     return 1
   fi
 
-  local -a args=(-y skills@latest remove "${removable[@]}" --global --agent '*' --yes)
+  # Omitting --agent targets every detected agent. skills@1.5.16 currently
+  # rejects the documented wildcard value (`--agent '*'`).
+  local -a args=(-y skills@latest remove "${removable[@]}" --global --yes)
   if ! DO_NOT_TRACK=1 npx "${args[@]}" </dev/null; then
     warn "npx skills could not migrate retired Matt Pocock skills: ${removable[*]}"
     return 1
@@ -1385,6 +1387,10 @@ remove_legacy_mattpocock_skills() {
   for skill in "${removable[@]}"; do
     rm -rf "$AGENTS_SKILLS_DIR/$skill" "$CODEX_DIR/skills/$skill"
   done
+  if ! remove_mattpocock_skill_lock_entries "${removable[@]}"; then
+    warn "Could not retire matching lock entries for retired Matt Pocock skills: ${removable[*]}"
+    return 1
+  fi
   remove_managed_skill_ownership "${removable[@]}"
   ok "Removed retired Matt Pocock skills: ${removable[*]}"
 }

--- a/install.sh
+++ b/install.sh
@@ -173,7 +173,11 @@ SUPERPOWERS_SKILLS=(
 )
 LOCAL_MANAGED_SKILLS=(paper-reading humanizer humanizer-zh handoff adversarial-review update)
 MANAGED_SKILLS_STATE_FILE="$CODEX_DIR/.awesome-claude-code-config-managed-skills"
-GLOBAL_SKILL_LOCK_FILE="$HOME/.agents/.skill-lock.json"
+if [[ -n "${XDG_STATE_HOME:-}" ]]; then
+  GLOBAL_SKILL_LOCK_FILE="$XDG_STATE_HOME/skills/.skill-lock.json"
+else
+  GLOBAL_SKILL_LOCK_FILE="$HOME/.agents/.skill-lock.json"
+fi
 CODEX_STATUS_LINE='status_line = ["model", "reasoning", "project-name", "git-branch", "context-used", "five-hour-limit", "weekly-limit"]'
 CODEX_STATUS_LINE_USE_COLORS='status_line_use_colors = true'
 PLAYWRIGHT_MCP_VERSION="0.0.78"

--- a/install.sh
+++ b/install.sh
@@ -66,6 +66,8 @@ LESSONS_SEEDED=false
 OWNED_MANAGED_SKILLS=()
 MANAGED_SKILLS_OWNERSHIP_LOADED=false
 MATTPOCOCK_QUICKSTART_READY=false
+MATTPOCOCK_VERSION="v1.1.0"
+MATTPOCOCK_COMMIT="d574778f94cf620fcc8ce741584093bc650a61d3"
 
 SELECT_CORE_AGENTS_MD=false
 SELECT_CORE_CONFIG=false
@@ -128,7 +130,7 @@ MANAGED_SKILLS=(
   frontend-slides
   ask-matt diagnosing-bugs grill-with-docs triage
   implement improve-codebase-architecture setup-matt-pocock-skills tdd
-  to-issues to-prd prototype domain-modeling codebase-design
+  to-spec to-tickets wayfinder prototype domain-modeling codebase-design
   grill-me grilling research teach writing-great-skills
   pua pua-en pua-ja
 )
@@ -138,9 +140,14 @@ LEGACY_CLEANUP_SKILLS=(
   security-review tdd-workflow verification-loop api-design database-migrations
 )
 
+MATTPOCOCK_LEGACY_SKILLS=(
+  to-issues to-prd decision-mapping review
+)
+
 OWNERSHIP_SKILLS=(
   "${MANAGED_SKILLS[@]}"
   "${LEGACY_CLEANUP_SKILLS[@]}"
+  "${MATTPOCOCK_LEGACY_SKILLS[@]}"
 )
 
 LEGACY_SUPERPOWERS_SKILLS=(
@@ -153,7 +160,7 @@ LEGACY_SUPERPOWERS_SKILLS=(
 MATTPOCOCK_SKILLS=(
   ask-matt diagnosing-bugs grill-with-docs triage
   implement improve-codebase-architecture setup-matt-pocock-skills tdd
-  to-issues to-prd prototype domain-modeling codebase-design
+  to-spec to-tickets wayfinder prototype domain-modeling codebase-design
   grill-me grilling research teach writing-great-skills
 )
 
@@ -182,7 +189,7 @@ show_mattpocock_quickstart() {
   echo "  Matt Pocock skills are already installed; do not run npx again."
   echo "  1. Restart Codex if it was open during installation."
   echo "  2. Type /skills (or press @), choose List skills, then search for setup-matt-pocock-skills."
-  echo "  3. Insert and run it; it will ask about your issue tracker, triage labels, and docs location."
+  echo "  3. Insert and run it; it will configure the issue tracker, triage labels when applicable, and domain docs."
   echo "  Note: installed skills are not individual root slash commands such as /setup-matt-pocock-skills."
 }
 
@@ -905,7 +912,9 @@ managed_skill_name_is_valid() {
 expected_source_for_skill() {
   local skill="$1"
 
-  if [[ "$skill" == "code-review" ]] || skill_in_array "$skill" "${MATTPOCOCK_SKILLS[@]}"; then
+  if [[ "$skill" == "code-review" ]] ||
+     skill_in_array "$skill" "${MATTPOCOCK_SKILLS[@]}" ||
+     skill_in_array "$skill" "${MATTPOCOCK_LEGACY_SKILLS[@]}"; then
     printf '%s\n' "mattpocock/skills"
   elif [[ "$skill" == "karpathy-guidelines" ]]; then
     printf '%s\n' "forrestchang/andrej-karpathy-skills"
@@ -1013,6 +1022,18 @@ for name, metadata in skills.items():
         if isinstance(source, str) and "\t" not in name and "\t" not in source:
             print(f"{name}\t{source}")
 PY
+}
+
+locked_skill_source_matches() {
+  local wanted_name="$1"
+  local wanted_source="$2"
+  local name source
+  while IFS=$'\t' read -r name source; do
+    if [[ "$name" == "$wanted_name" && "$source" == "$wanted_source" ]]; then
+      return 0
+    fi
+  done < <(legacy_locked_skill_pairs)
+  return 1
 }
 
 superpowers_fallback_is_owned() {
@@ -1133,6 +1154,51 @@ confirm_empty_skill_removal() {
   [[ "$answer" =~ ^[Yy]$ ]]
 }
 
+verify_installed_skill_names() {
+  local -a missing=()
+  local skill
+  for skill in "$@"; do
+    if [[ ! -f "$AGENTS_SKILLS_DIR/$skill/SKILL.md" &&
+          ! -f "$CODEX_DIR/skills/$skill/SKILL.md" ]]; then
+      missing+=("$skill")
+    fi
+  done
+
+  if [[ ${#missing[@]} -gt 0 ]]; then
+    warn "npx skills returned success but did not install: ${missing[*]}"
+    return 1
+  fi
+  return 0
+}
+
+remove_mattpocock_skill_lock_entries() {
+  [[ -f "$GLOBAL_SKILL_LOCK_FILE" ]] || return 0
+  command -v node >/dev/null 2>&1 || return 1
+
+  node - "$GLOBAL_SKILL_LOCK_FILE" "$@" <<'NODE'
+const fs = require("fs");
+
+const [lockPath, ...names] = process.argv.slice(2);
+let lock;
+try {
+  lock = JSON.parse(fs.readFileSync(lockPath, "utf8"));
+} catch {
+  process.exit(1);
+}
+
+if (!lock.skills || typeof lock.skills !== "object") process.exit(0);
+for (const name of names) {
+  if (lock.skills[name]?.source === "mattpocock/skills") {
+    delete lock.skills[name];
+  }
+}
+
+const tempPath = `${lockPath}.tmp.${process.pid}`;
+fs.writeFileSync(tempPath, `${JSON.stringify(lock, null, 2)}\n`, "utf8");
+fs.renameSync(tempPath, lockPath);
+NODE
+}
+
 install_npx_skill_names() {
   local repo="$1"
   shift
@@ -1154,11 +1220,86 @@ install_npx_skill_names() {
     args+=(--skill "$skill")
   done
 
-  if DO_NOT_TRACK=1 npx "${args[@]}" </dev/null; then
+  if DO_NOT_TRACK=1 npx "${args[@]}" </dev/null &&
+     verify_installed_skill_names "${skill_names[@]}"; then
     add_managed_skill_ownership "${skill_names[@]}"
     return 0
   fi
   return 1
+}
+
+install_mattpocock_skill_names() {
+  local -a skill_names=("$@")
+
+  remove_legacy_mattpocock_skills || return 1
+
+  if $DRY_RUN; then
+    info "Would install Matt Pocock $MATTPOCOCK_VERSION from commit $MATTPOCOCK_COMMIT: $*"
+    return 0
+  fi
+
+  if ! command -v tar >/dev/null 2>&1; then
+    warn "tar not found; cannot unpack pinned Matt Pocock skills"
+    return 1
+  fi
+
+  local temp_dir archive source_dir skill
+  temp_dir=$(mktemp -d "${TMPDIR:-/tmp}/mattpocock-skills.XXXXXX")
+  archive="$temp_dir/source.tar.gz"
+
+  if ! download_archive \
+    "https://github.com/mattpocock/skills/archive/${MATTPOCOCK_COMMIT}.tar.gz" \
+    "$archive"; then
+    rm -rf "$temp_dir"
+    warn "Could not download Matt Pocock $MATTPOCOCK_VERSION"
+    return 1
+  fi
+
+  if ! tar -xzf "$archive" -C "$temp_dir"; then
+    rm -rf "$temp_dir"
+    warn "Could not unpack Matt Pocock $MATTPOCOCK_VERSION"
+    return 1
+  fi
+
+  source_dir=$(find "$temp_dir" -mindepth 1 -maxdepth 1 -type d -print -quit)
+  if [[ -z "$source_dir" ]]; then
+    rm -rf "$temp_dir"
+    warn "Pinned Matt Pocock archive did not contain a repository root"
+    return 1
+  fi
+
+  for skill in "${skill_names[@]}"; do
+    if ! find "$source_dir/skills" -path "*/$skill/SKILL.md" -type f -print -quit | grep -q .; then
+      rm -rf "$temp_dir"
+      warn "Pinned Matt Pocock archive is missing requested skill: $skill"
+      return 1
+    fi
+  done
+
+  local result=0 source_skill target_skill
+  install_npx_skill_names "$source_dir" "${skill_names[@]}" || result=$?
+  if [[ "$result" -eq 0 ]]; then
+    for skill in "${skill_names[@]}"; do
+      source_skill=$(find "$source_dir/skills" -path "*/$skill/SKILL.md" -type f -print -quit)
+      source_skill=${source_skill%/SKILL.md}
+      target_skill="$AGENTS_SKILLS_DIR/$skill"
+      [[ -d "$target_skill" ]] || target_skill="$CODEX_DIR/skills/$skill"
+      if ! managed_directory_trees_equal "$source_skill" "$target_skill"; then
+        warn "Installed Matt Pocock skill does not match pinned snapshot: $skill"
+        remove_managed_skill_ownership "${skill_names[@]}"
+        result=1
+        break
+      fi
+    done
+  fi
+  if [[ "$result" -eq 0 ]] &&
+     ! remove_mattpocock_skill_lock_entries "${skill_names[@]}"; then
+    warn "Could not retire remote Matt Pocock lock entries after pinned installation"
+    remove_managed_skill_ownership "${skill_names[@]}"
+    result=1
+  fi
+  rm -rf "$temp_dir"
+  return "$result"
 }
 
 selected_managed_skill_names() {
@@ -1208,6 +1349,43 @@ remove_npx_skill_names() {
   fi
 }
 
+remove_legacy_mattpocock_skills() {
+  initialize_managed_skill_ownership
+
+  local -a removable=()
+  local skill
+  for skill in "${MATTPOCOCK_LEGACY_SKILLS[@]}"; do
+    if owned_managed_skill_contains "$skill" ||
+       locked_skill_source_matches "$skill" "mattpocock/skills"; then
+      removable+=("$skill")
+    fi
+  done
+
+  [[ ${#removable[@]} -gt 0 ]] || return 0
+
+  if $DRY_RUN; then
+    info "Would remove retired Matt Pocock skills from all agent associations: ${removable[*]}"
+    return 0
+  fi
+
+  if ! command -v npx >/dev/null 2>&1; then
+    warn "npx not found; cannot safely migrate retired Matt Pocock skills: ${removable[*]}"
+    return 1
+  fi
+
+  local -a args=(-y skills@latest remove "${removable[@]}" --global --agent '*' --yes)
+  if ! DO_NOT_TRACK=1 npx "${args[@]}" </dev/null; then
+    warn "npx skills could not migrate retired Matt Pocock skills: ${removable[*]}"
+    return 1
+  fi
+
+  for skill in "${removable[@]}"; do
+    rm -rf "$AGENTS_SKILLS_DIR/$skill" "$CODEX_DIR/skills/$skill"
+  done
+  remove_managed_skill_ownership "${removable[@]}"
+  ok "Removed retired Matt Pocock skills: ${removable[*]}"
+}
+
 remove_superpowers_fallback() {
   if ! superpowers_fallback_is_owned; then
     if [[ -L "$SUPERPOWERS_LINK" || -e "$SUPERPOWERS_LINK" || -e "$SUPERPOWERS_DIR" ]]; then
@@ -1254,6 +1432,9 @@ reconcile_interactive_skills() {
   local skill wanted selected
 
   initialize_managed_skill_ownership
+  if ! remove_legacy_mattpocock_skills; then
+    warn "Retired Matt Pocock skills were preserved because migration cleanup failed"
+  fi
 
   while IFS= read -r skill; do
     [[ -n "$skill" ]] && desired+=("$skill")
@@ -1261,6 +1442,7 @@ reconcile_interactive_skills() {
 
   if [[ ${#OWNED_MANAGED_SKILLS[@]} -gt 0 ]]; then
     for skill in "${OWNED_MANAGED_SKILLS[@]}"; do
+      skill_in_array "$skill" "${MATTPOCOCK_LEGACY_SKILLS[@]}" && continue
       wanted=false
       if [[ ${#desired[@]} -gt 0 ]]; then
         for selected in "${desired[@]}"; do
@@ -1525,7 +1707,7 @@ install_local_skills() {
 
 install_selected_recommended_skills() {
   if $SELECT_SKILL_CODE_REVIEW; then
-    install_npx_skill_names mattpocock/skills code-review || \
+    install_mattpocock_skill_names code-review || \
       skip_unsupported_item "code-review" "npx skills install failed; use Codex /review as the native fallback"
   fi
 
@@ -1539,7 +1721,7 @@ install_selected_recommended_skills() {
   fi
 
   if $SELECT_SKILL_MATTPOCOCK; then
-    if install_npx_skill_names mattpocock/skills "${MATTPOCOCK_SKILLS[@]}"; then
+    if install_mattpocock_skill_names "${MATTPOCOCK_SKILLS[@]}"; then
       MATTPOCOCK_QUICKSTART_READY=true
     else
       skip_unsupported_item "mattpocock/skills" "npx skills install failed"
@@ -1628,7 +1810,7 @@ install_skills() {
   info "Installing skills (group: $SKILL_GROUP)..."
 
   if [[ "$SKILL_GROUP" == "core" || "$SKILL_GROUP" == "all" ]]; then
-    install_npx_skill_names mattpocock/skills code-review || \
+    install_mattpocock_skill_names code-review || \
       skip_unsupported_item "code-review" "npx skills install failed; use Codex /review as the native fallback"
 
     install_npx_skill_names forrestchang/andrej-karpathy-skills karpathy-guidelines || \
@@ -1636,7 +1818,7 @@ install_skills() {
 
     install_superpowers
 
-    if install_npx_skill_names mattpocock/skills "${MATTPOCOCK_SKILLS[@]}"; then
+    if install_mattpocock_skill_names "${MATTPOCOCK_SKILLS[@]}"; then
       MATTPOCOCK_QUICKSTART_READY=true
     else
       skip_unsupported_item "mattpocock/skills" "npx skills install failed"

--- a/tests/check_codex_migration.sh
+++ b/tests/check_codex_migration.sh
@@ -112,6 +112,9 @@ assert_file_contains "install.sh" "not individual root slash commands"
 assert_file_contains "install.sh" "superpowers_ownership_is_recorded"
 assert_file_contains "install.sh" "skills@latest remove"
 assert_file_contains "install.sh" "--global --agent codex --yes"
+assert_file_contains "install.sh" "remove_legacy_mattpocock_skills"
+assert_file_contains "install.sh" "locked_skill_source_matches"
+assert_file_contains "install.sh" "--global --agent '*' --yes"
 assert_file_not_contains "install.sh" "SELECT_SKILL_CODING_FOUNDATIONS"
 assert_file_contains "install.sh" "handoff|Conversation handoff skill|1|skill-handoff"
 assert_file_not_contains "install.sh" '-e "$AGENTS_SKILLS_DIR/$skill"'
@@ -135,9 +138,11 @@ assert_file_contains "install.ps1" "Type /skills (or press @)"
 assert_file_contains "install.ps1" "not individual root slash commands"
 assert_file_contains "install.ps1" "function Test-SuperpowersOwnershipRecorded"
 assert_file_contains "install.ps1" '"--global", "--agent", "codex", "--yes"'
+assert_file_contains "install.ps1" "function Remove-LegacyMattPocockSkills"
+assert_file_contains "install.ps1" "function Test-LockedSkillSource"
+assert_file_contains "install.ps1" '@("--global", "--agent", "*", "--yes")'
 assert_file_contains "install.ps1" 'Label = "handoff"; Description = "Conversation handoff skill"; Default = $true; StateVar = "SelectSkillHandoff"'
 assert_file_not_contains "install.ps1" 'SelectSkillCodingFoundations'
-assert_file_not_contains "install.ps1" 'Join-Path $AGENTS_SKILLS_DIR $skill'
 assert_file_contains "install.ps1" "Resolve-PythonCommand"
 
 assert_file_contains "install.sh" "affaan-m/everything-claude-code"
@@ -303,6 +308,38 @@ for array_name in ("SUPERPOWERS_SKILLS", "MATTPOCOCK_SKILLS", "PUA_SKILLS"):
     missing = sorted(set(bash_values) - bash_skills)
     if missing:
         raise SystemExit(f"{array_name} contains unmanaged skills: {', '.join(missing)}")
+
+expected_mattpocock = {
+    "ask-matt", "diagnosing-bugs", "grill-with-docs", "triage", "implement",
+    "improve-codebase-architecture", "setup-matt-pocock-skills", "tdd",
+    "to-spec", "to-tickets", "wayfinder", "prototype", "domain-modeling",
+    "codebase-design", "grill-me", "grilling", "research", "teach",
+    "writing-great-skills",
+}
+retired_mattpocock = {"to-issues", "to-prd", "decision-mapping", "review"}
+for label, text in (("install.sh", bash), ("install.ps1", ps)):
+    if label == "install.sh":
+        current = set(re.search(
+            r"(?m)^MATTPOCOCK_SKILLS=\((?P<body>.*?)\)", text, re.S
+        ).group("body").split())
+        legacy = set(re.search(
+            r"(?m)^MATTPOCOCK_LEGACY_SKILLS=\((?P<body>.*?)\)", text, re.S
+        ).group("body").split())
+    else:
+        current = set(re.findall(r'"([^"]+)"', re.search(
+            r"(?m)^\$MATTPOCOCK_SKILLS = @\((?P<body>.*?)\)", text, re.S
+        ).group("body")))
+        legacy = set(re.findall(r'"([^"]+)"', re.search(
+            r"(?m)^\$MATTPOCOCK_LEGACY_SKILLS = @\((?P<body>.*?)\)", text, re.S
+        ).group("body")))
+    if current != expected_mattpocock:
+        raise SystemExit(f"{label} Matt Pocock v1.1 manifest is incorrect: {sorted(current)}")
+    if legacy != retired_mattpocock:
+        raise SystemExit(f"{label} Matt Pocock legacy manifest is incorrect: {sorted(legacy)}")
+
+mattpocock_commit = "d574778f94cf620fcc8ce741584093bc650a61d3"
+if bash.count(mattpocock_commit) != 1 or ps.count(mattpocock_commit) != 1:
+    raise SystemExit("both installers must pin the Matt Pocock v1.1.0 release commit exactly once")
 
 if bash.count("reconcile_interactive_skills") != 2:
     raise SystemExit("Bash reconciliation should have exactly one definition and one interactive call")

--- a/tests/check_codex_migration.sh
+++ b/tests/check_codex_migration.sh
@@ -142,6 +142,8 @@ assert_file_contains "install.ps1" "function Test-SuperpowersOwnershipRecorded"
 assert_file_contains "install.ps1" '"--global", "--agent", "codex", "--yes"'
 assert_file_contains "install.ps1" "function Remove-LegacyMattPocockSkills"
 assert_file_contains "install.ps1" "function Test-LockedSkillSource"
+assert_file_contains "install.ps1" "function Get-GlobalSkillLockFile"
+assert_file_contains "install.ps1" '$GLOBAL_SKILL_LOCK_FILE = Get-GlobalSkillLockFile'
 assert_file_contains "install.ps1" '$env:XDG_STATE_HOME'
 assert_file_contains "install.ps1" 'skills/.skill-lock.json'
 assert_file_contains "install.ps1" '@("--global", "--yes")'

--- a/tests/check_codex_migration.sh
+++ b/tests/check_codex_migration.sh
@@ -114,6 +114,8 @@ assert_file_contains "install.sh" "skills@latest remove"
 assert_file_contains "install.sh" "--global --agent codex --yes"
 assert_file_contains "install.sh" "remove_legacy_mattpocock_skills"
 assert_file_contains "install.sh" "locked_skill_source_matches"
+assert_file_contains "install.sh" 'XDG_STATE_HOME'
+assert_file_contains "install.sh" 'skills/.skill-lock.json'
 assert_file_contains "install.sh" 'local -a args=(-y skills@latest remove "${removable[@]}" --global --yes)'
 assert_file_not_contains "install.sh" "SELECT_SKILL_CODING_FOUNDATIONS"
 assert_file_contains "install.sh" "handoff|Conversation handoff skill|1|skill-handoff"
@@ -140,6 +142,8 @@ assert_file_contains "install.ps1" "function Test-SuperpowersOwnershipRecorded"
 assert_file_contains "install.ps1" '"--global", "--agent", "codex", "--yes"'
 assert_file_contains "install.ps1" "function Remove-LegacyMattPocockSkills"
 assert_file_contains "install.ps1" "function Test-LockedSkillSource"
+assert_file_contains "install.ps1" '$env:XDG_STATE_HOME'
+assert_file_contains "install.ps1" 'skills/.skill-lock.json'
 assert_file_contains "install.ps1" '@("--global", "--yes")'
 assert_file_contains "install.ps1" 'Label = "handoff"; Description = "Conversation handoff skill"; Default = $true; StateVar = "SelectSkillHandoff"'
 assert_file_not_contains "install.ps1" 'SelectSkillCodingFoundations'

--- a/tests/check_codex_migration.sh
+++ b/tests/check_codex_migration.sh
@@ -114,7 +114,7 @@ assert_file_contains "install.sh" "skills@latest remove"
 assert_file_contains "install.sh" "--global --agent codex --yes"
 assert_file_contains "install.sh" "remove_legacy_mattpocock_skills"
 assert_file_contains "install.sh" "locked_skill_source_matches"
-assert_file_contains "install.sh" "--global --agent '*' --yes"
+assert_file_contains "install.sh" 'local -a args=(-y skills@latest remove "${removable[@]}" --global --yes)'
 assert_file_not_contains "install.sh" "SELECT_SKILL_CODING_FOUNDATIONS"
 assert_file_contains "install.sh" "handoff|Conversation handoff skill|1|skill-handoff"
 assert_file_not_contains "install.sh" '-e "$AGENTS_SKILLS_DIR/$skill"'
@@ -140,7 +140,7 @@ assert_file_contains "install.ps1" "function Test-SuperpowersOwnershipRecorded"
 assert_file_contains "install.ps1" '"--global", "--agent", "codex", "--yes"'
 assert_file_contains "install.ps1" "function Remove-LegacyMattPocockSkills"
 assert_file_contains "install.ps1" "function Test-LockedSkillSource"
-assert_file_contains "install.ps1" '@("--global", "--agent", "*", "--yes")'
+assert_file_contains "install.ps1" '@("--global", "--yes")'
 assert_file_contains "install.ps1" 'Label = "handoff"; Description = "Conversation handoff skill"; Default = $true; StateVar = "SelectSkillHandoff"'
 assert_file_not_contains "install.ps1" 'SelectSkillCodingFoundations'
 assert_file_contains "install.ps1" "Resolve-PythonCommand"

--- a/tests/check_codex_skill_reconciliation.sh
+++ b/tests/check_codex_skill_reconciliation.sh
@@ -119,7 +119,7 @@ write_owned_skills() {
 }
 
 reset_ownership_discovery() {
-  rm -f "$MANAGED_SKILLS_STATE_FILE" "$HOME/.agents/.skill-lock.json"
+  rm -f "$MANAGED_SKILLS_STATE_FILE" "$GLOBAL_SKILL_LOCK_FILE"
   MANAGED_SKILLS_OWNERSHIP_LOADED=false
   OWNED_MANAGED_SKILLS=()
 }
@@ -210,16 +210,17 @@ assert_missing "$CODEX_DIR/skills/humanizer-zh"
 
 # A lock entry is imported only when its source matches the installer source.
 reset_ownership_discovery
-mkdir -p "$CODEX_DIR/skills/research" "$HOME/.agents"
-printf '%s\n' '{"version":3,"skills":{"research":{"source":"user/custom-skills"}}}' > "$HOME/.agents/.skill-lock.json"
+mkdir -p "$CODEX_DIR/skills/research" "$(dirname "$GLOBAL_SKILL_LOCK_FILE")"
+printf '%s\n' '{"version":3,"skills":{"research":{"source":"user/custom-skills"}}}' > "$GLOBAL_SKILL_LOCK_FILE"
 reconcile_interactive_skills
 assert_exists "$CODEX_DIR/skills/research"
 
 reset_ownership_discovery
-mkdir -p "$CODEX_DIR/skills/frontend-slides" "$AGENTS_SKILLS_DIR/frontend-slides" "$HOME/.agents"
+mkdir -p "$CODEX_DIR/skills/frontend-slides" "$AGENTS_SKILLS_DIR/frontend-slides" \
+  "$(dirname "$GLOBAL_SKILL_LOCK_FILE")"
 printf '%s\n' custom > "$CODEX_DIR/skills/frontend-slides/SKILL.md"
 printf '%s\n' upstream > "$AGENTS_SKILLS_DIR/frontend-slides/SKILL.md"
-printf '%s\n' '{"version":3,"skills":{"frontend-slides":{"source":"zarazhangrui/frontend-slides"}}}' > "$HOME/.agents/.skill-lock.json"
+printf '%s\n' '{"version":3,"skills":{"frontend-slides":{"source":"zarazhangrui/frontend-slides"}}}' > "$GLOBAL_SKILL_LOCK_FILE"
 reconcile_interactive_skills
 assert_exists "$CODEX_DIR/skills/frontend-slides"
 assert_exists "$AGENTS_SKILLS_DIR/frontend-slides"
@@ -227,7 +228,7 @@ assert_exists "$AGENTS_SKILLS_DIR/frontend-slides"
 reset_ownership_discovery
 rm -rf "$CODEX_DIR/skills/frontend-slides"
 cp -R "$AGENTS_SKILLS_DIR/frontend-slides" "$CODEX_DIR/skills/frontend-slides"
-printf '%s\n' '{"version":3,"skills":{"frontend-slides":{"source":"zarazhangrui/frontend-slides"}}}' > "$HOME/.agents/.skill-lock.json"
+printf '%s\n' '{"version":3,"skills":{"frontend-slides":{"source":"zarazhangrui/frontend-slides"}}}' > "$GLOBAL_SKILL_LOCK_FILE"
 reconcile_interactive_skills
 assert_missing "$CODEX_DIR/skills/frontend-slides"
 assert_exists "$AGENTS_SKILLS_DIR/frontend-slides"
@@ -235,10 +236,11 @@ assert_exists "$AGENTS_SKILLS_DIR/frontend-slides"
 # Retired coding-foundations names remain cleanup-only: they cannot be selected
 # or installed, but a verified legacy copy is removed on the first upgrade.
 reset_ownership_discovery
-mkdir -p "$CODEX_DIR/skills/python-patterns" "$AGENTS_SKILLS_DIR/python-patterns" "$HOME/.agents"
+mkdir -p "$CODEX_DIR/skills/python-patterns" "$AGENTS_SKILLS_DIR/python-patterns" \
+  "$(dirname "$GLOBAL_SKILL_LOCK_FILE")"
 printf '%s\n' legacy > "$AGENTS_SKILLS_DIR/python-patterns/SKILL.md"
 cp "$AGENTS_SKILLS_DIR/python-patterns/SKILL.md" "$CODEX_DIR/skills/python-patterns/SKILL.md"
-printf '%s\n' '{"version":3,"skills":{"python-patterns":{"source":"affaan-m/everything-claude-code"}}}' > "$HOME/.agents/.skill-lock.json"
+printf '%s\n' '{"version":3,"skills":{"python-patterns":{"source":"affaan-m/everything-claude-code"}}}' > "$GLOBAL_SKILL_LOCK_FILE"
 reconcile_interactive_skills
 assert_missing "$CODEX_DIR/skills/python-patterns"
 assert_exists "$AGENTS_SKILLS_DIR/python-patterns"

--- a/tests/check_codex_skill_reconciliation.sh
+++ b/tests/check_codex_skill_reconciliation.sh
@@ -381,9 +381,16 @@ download_archive() {
 reset_ownership_discovery
 mkdir -p "$AGENTS_SKILLS_DIR/to-spec"
 printf '%s\n' stale > "$AGENTS_SKILLS_DIR/to-spec/SKILL.md"
+write_owned_skills ask-matt to-spec
 if NPX_SKIP_SKILL=to-spec TMPDIR="$TMP" \
   install_mattpocock_skill_names ask-matt to-spec; then
   fail "stale Matt Pocock content was accepted as the pinned snapshot"
+fi
+if [[ -f "$MANAGED_SKILLS_STATE_FILE" ]]; then
+  grep -Fxq ask-matt "$MANAGED_SKILLS_STATE_FILE" && \
+    fail "failed pinned upgrade retained ask-matt ownership"
+  grep -Fxq to-spec "$MANAGED_SKILLS_STATE_FILE" && \
+    fail "failed pinned upgrade retained to-spec ownership"
 fi
 rm -rf "$AGENTS_SKILLS_DIR/ask-matt" "$AGENTS_SKILLS_DIR/to-spec"
 mkdir -p "$(dirname "$GLOBAL_SKILL_LOCK_FILE")"

--- a/tests/check_codex_skill_reconciliation.sh
+++ b/tests/check_codex_skill_reconciliation.sh
@@ -359,8 +359,14 @@ assert_missing "$AGENTS_SKILLS_DIR/to-issues"
 if grep -Fq -- '--agent *' "$NPX_LOG"; then
   fail "legacy Matt Pocock cleanup used the CLI's invalid wildcard agent"
 fi
-grep -Fq -- 'skills@latest remove to-prd to-issues --global --yes' "$NPX_LOG" || \
+legacy_remove_call="$(tail -n 1 "$NPX_LOG")"
+[[ "$legacy_remove_call" == *"skills@latest remove "* &&
+   "$legacy_remove_call" == *" --global --yes"* ]] || \
   fail "legacy Matt Pocock cleanup did not use default all-agent removal"
+for retired_skill in to-prd to-issues; do
+  [[ " $legacy_remove_call " == *" $retired_skill "* ]] || \
+    fail "legacy Matt Pocock cleanup omitted $retired_skill"
+done
 if [[ -f "$MANAGED_SKILLS_STATE_FILE" ]]; then
   grep -Fxq to-prd "$MANAGED_SKILLS_STATE_FILE" && \
     fail "retired to-prd ownership survived migration"

--- a/tests/check_codex_skill_reconciliation.sh
+++ b/tests/check_codex_skill_reconciliation.sh
@@ -33,8 +33,18 @@ if [[ " $* " == *" add "* ]]; then
 fi
 
 if [[ " $* " == *" remove "* ]]; then
-  remove_all_agents=false
-  [[ " $* " == *" --agent * --yes "* ]] && remove_all_agents=true
+  remove_all_agents=true
+  previous=""
+  for arg in "$@"; do
+    if [[ "$previous" == "--agent" ]]; then
+      # skills@1.5.16 documents '*' but currently rejects it as an invalid
+      # agent. Omitting --agent is the supported all-agent removal path.
+      [[ "$arg" == "*" ]] && exit 1
+      remove_all_agents=false
+      break
+    fi
+    previous="$arg"
+  done
   removing=false
   for arg in "$@"; do
     if [[ "$arg" == "remove" ]]; then
@@ -338,19 +348,36 @@ reset_ownership_discovery
 mkdir -p "$AGENTS_SKILLS_DIR/to-prd" "$AGENTS_SKILLS_DIR/to-issues"
 printf '%s\n' legacy > "$AGENTS_SKILLS_DIR/to-prd/SKILL.md"
 printf '%s\n' legacy > "$AGENTS_SKILLS_DIR/to-issues/SKILL.md"
+mkdir -p "$(dirname "$GLOBAL_SKILL_LOCK_FILE")"
+printf '%s\n' '{"version":3,"skills":{"to-prd":{"source":"mattpocock/skills"},"to-issues":{"source":"mattpocock/skills"},"custom-skill":{"source":"user/custom-skills"}}}' > \
+  "$GLOBAL_SKILL_LOCK_FILE"
 write_owned_skills to-prd to-issues
 : > "$NPX_LOG"
 remove_legacy_mattpocock_skills || fail "legacy Matt Pocock cleanup failed"
 assert_missing "$AGENTS_SKILLS_DIR/to-prd"
 assert_missing "$AGENTS_SKILLS_DIR/to-issues"
-grep -Fq -- '--agent * --yes' "$NPX_LOG" || \
-  fail "legacy Matt Pocock cleanup did not remove all shared-agent associations"
+if grep -Fq -- '--agent *' "$NPX_LOG"; then
+  fail "legacy Matt Pocock cleanup used the CLI's invalid wildcard agent"
+fi
+grep -Fq -- 'skills@latest remove to-prd to-issues --global --yes' "$NPX_LOG" || \
+  fail "legacy Matt Pocock cleanup did not use default all-agent removal"
 if [[ -f "$MANAGED_SKILLS_STATE_FILE" ]]; then
   grep -Fxq to-prd "$MANAGED_SKILLS_STATE_FILE" && \
     fail "retired to-prd ownership survived migration"
   grep -Fxq to-issues "$MANAGED_SKILLS_STATE_FILE" && \
     fail "retired to-issues ownership survived migration"
 fi
+python3 - "$GLOBAL_SKILL_LOCK_FILE" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as fh:
+    skills = json.load(fh)["skills"]
+if "to-prd" in skills or "to-issues" in skills:
+    raise SystemExit("retired Matt Pocock lock entries survived migration")
+if skills.get("custom-skill", {}).get("source") != "user/custom-skills":
+    raise SystemExit("unrelated skill lock entry changed during legacy cleanup")
+PY
 
 reset_ownership_discovery
 mkdir -p "$AGENTS_SKILLS_DIR/review" "$(dirname "$GLOBAL_SKILL_LOCK_FILE")"

--- a/tests/check_codex_skill_reconciliation.sh
+++ b/tests/check_codex_skill_reconciliation.sh
@@ -6,6 +6,7 @@ TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
 export HOME="$TMP/home"
+export XDG_STATE_HOME="$TMP/xdg-state"
 export NPX_LOG="$TMP/npx.log"
 mkdir -p "$HOME" "$TMP/bin"
 sed '$d' "$ROOT/install.sh" > "$TMP/install-lib.sh"
@@ -73,6 +74,9 @@ fail() {
   printf 'FAIL: %s\n' "$*" >&2
   exit 1
 }
+
+[[ "$GLOBAL_SKILL_LOCK_FILE" == "$XDG_STATE_HOME/skills/.skill-lock.json" ]] ||
+  fail "global skill lock path did not honor XDG_STATE_HOME"
 
 assert_exists() {
   [[ -e "$1" || -L "$1" ]] || fail "expected path to exist: $1"

--- a/tests/check_codex_skill_reconciliation.sh
+++ b/tests/check_codex_skill_reconciliation.sh
@@ -16,6 +16,40 @@ printf '%s\n' "$*" >> "$NPX_LOG"
 if [[ "${NPX_FAIL:-false}" == "true" ]]; then
   exit 1
 fi
+
+if [[ " $* " == *" add "* ]]; then
+  while [[ $# -gt 0 ]]; do
+    if [[ "$1" == "--skill" && $# -ge 2 ]]; then
+      skill="$2"
+      if [[ "$skill" != "${NPX_SKIP_SKILL:-}" ]]; then
+        mkdir -p "$HOME/.agents/skills/$skill"
+        printf '%s\n' '---' "name: $skill" '---' > "$HOME/.agents/skills/$skill/SKILL.md"
+      fi
+      shift 2
+      continue
+    fi
+    shift
+  done
+fi
+
+if [[ " $* " == *" remove "* ]]; then
+  remove_all_agents=false
+  [[ " $* " == *" --agent * --yes "* ]] && remove_all_agents=true
+  removing=false
+  for arg in "$@"; do
+    if [[ "$arg" == "remove" ]]; then
+      removing=true
+      continue
+    fi
+    $removing || continue
+    [[ "$arg" == --* ]] && break
+    rm -rf "$HOME/.codex/skills/$arg"
+    if $remove_all_agents; then
+      rm -rf "$HOME/.agents/skills/$arg" "$HOME/.claude/skills/$arg" \
+        "$HOME/.openclaw/skills/$arg"
+    fi
+  done
+fi
 SH
 chmod +x "$TMP/bin/npx"
 export PATH="$TMP/bin:$PATH"
@@ -102,6 +136,20 @@ sort -u "$reachable_file" -o "$reachable_file"
 for managed_skill in "${MANAGED_SKILLS[@]}"; do
   grep -Fxq "$managed_skill" "$reachable_file" || \
     fail "managed skill is unreachable from every selection: $managed_skill"
+done
+
+# The Matt Pocock selection follows the pinned v1.1 workflow vocabulary.
+clear_skill_selections
+SELECT_SKILL_MATTPOCOCK=true
+mattpocock_selection="$(selected_managed_skill_names)"
+for skill in to-spec to-tickets wayfinder; do
+  grep -Fxq "$skill" <<< "$mattpocock_selection" || \
+    fail "Matt Pocock selection is missing v1.1 skill: $skill"
+done
+for skill in to-prd to-issues decision-mapping review; do
+  if grep -Fxq "$skill" <<< "$mattpocock_selection"; then
+    fail "Matt Pocock selection still exposes retired skill: $skill"
+  fi
 done
 
 clear_skill_selections
@@ -225,6 +273,21 @@ grep -Fxq humanizer "$MANAGED_SKILLS_STATE_FILE" || fail "local install did not 
 install_npx_skill_names zarazhangrui/frontend-slides frontend-slides
 grep -Fxq frontend-slides "$MANAGED_SKILLS_STATE_FILE" || fail "npx install did not record ownership"
 
+# A zero exit from npx is insufficient when it silently skips a requested
+# skill. The installer must verify every requested directory before recording
+# ownership or reporting success.
+reset_ownership_discovery
+rm -rf "$AGENTS_SKILLS_DIR/to-spec" "$AGENTS_SKILLS_DIR/to-tickets"
+if NPX_SKIP_SKILL=to-tickets install_npx_skill_names mattpocock/skills to-spec to-tickets; then
+  fail "partial npx install was reported as successful"
+fi
+if [[ -f "$MANAGED_SKILLS_STATE_FILE" ]]; then
+  grep -Fxq to-spec "$MANAGED_SKILLS_STATE_FILE" && \
+    fail "partial npx install recorded ownership"
+  grep -Fxq to-tickets "$MANAGED_SKILLS_STATE_FILE" && \
+    fail "missing npx skill recorded ownership"
+fi
+
 # Empty skill selections require a second confirmation before bulk removal.
 mkdir -p "$CODEX_DIR/skills/pua"
 write_owned_skills pua
@@ -245,7 +308,8 @@ assert_exists "$noninteractive_home/.codex/skills/pua"
 clear_skill_selections
 SELECT_SKILL_MATTPOCOCK=true
 MATTPOCOCK_QUICKSTART_READY=false
-install_npx_skill_names() { return 0; }
+real_install_mattpocock_skill_names="$(declare -f install_mattpocock_skill_names)"
+install_mattpocock_skill_names() { return 0; }
 install_selected_recommended_skills >/dev/null
 $MATTPOCOCK_QUICKSTART_READY || fail "successful Matt Pocock install did not enable the quickstart"
 quickstart_output="$(show_mattpocock_quickstart)"
@@ -257,7 +321,7 @@ quickstart_output="$(show_mattpocock_quickstart)"
 
 MATTPOCOCK_QUICKSTART_READY=false
 SKIPPED_COMPONENTS=()
-install_npx_skill_names() { return 1; }
+install_mattpocock_skill_names() { return 1; }
 install_selected_recommended_skills >/dev/null 2>&1
 $MATTPOCOCK_QUICKSTART_READY && fail "failed Matt Pocock install enabled the quickstart"
 
@@ -265,5 +329,86 @@ MATTPOCOCK_QUICKSTART_READY=true
 DRY_RUN=true
 [[ -z "$(show_mattpocock_quickstart)" ]] || fail "dry-run displayed the installed quickstart"
 DRY_RUN=false
+eval "$real_install_mattpocock_skill_names"
+
+# Retired Matt Pocock names are removed from the shared canonical directory
+# only when ownership/provenance is known, and their ownership records are
+# retired with them.
+reset_ownership_discovery
+mkdir -p "$AGENTS_SKILLS_DIR/to-prd" "$AGENTS_SKILLS_DIR/to-issues"
+printf '%s\n' legacy > "$AGENTS_SKILLS_DIR/to-prd/SKILL.md"
+printf '%s\n' legacy > "$AGENTS_SKILLS_DIR/to-issues/SKILL.md"
+write_owned_skills to-prd to-issues
+: > "$NPX_LOG"
+remove_legacy_mattpocock_skills || fail "legacy Matt Pocock cleanup failed"
+assert_missing "$AGENTS_SKILLS_DIR/to-prd"
+assert_missing "$AGENTS_SKILLS_DIR/to-issues"
+grep -Fq -- '--agent * --yes' "$NPX_LOG" || \
+  fail "legacy Matt Pocock cleanup did not remove all shared-agent associations"
+if [[ -f "$MANAGED_SKILLS_STATE_FILE" ]]; then
+  grep -Fxq to-prd "$MANAGED_SKILLS_STATE_FILE" && \
+    fail "retired to-prd ownership survived migration"
+  grep -Fxq to-issues "$MANAGED_SKILLS_STATE_FILE" && \
+    fail "retired to-issues ownership survived migration"
+fi
+
+reset_ownership_discovery
+mkdir -p "$AGENTS_SKILLS_DIR/review" "$(dirname "$GLOBAL_SKILL_LOCK_FILE")"
+printf '%s\n' custom > "$AGENTS_SKILLS_DIR/review/SKILL.md"
+printf '%s\n' '{"version":3,"skills":{"review":{"source":"user/custom-skills"}}}' > \
+  "$GLOBAL_SKILL_LOCK_FILE"
+remove_legacy_mattpocock_skills || fail "custom-name provenance check failed"
+assert_exists "$AGENTS_SKILLS_DIR/review"
+
+# Matt Pocock installs use an immutable source snapshot. The skills CLI
+# currently ignores remote tag/commit suffixes, so the installer downloads the
+# pinned archive first and then installs from that local directory.
+pinned_fixture="$TMP/pinned-mattpocock/skills-test"
+mkdir -p "$pinned_fixture/skills/engineering/ask-matt" \
+  "$pinned_fixture/skills/engineering/to-spec"
+printf '%s\n' '---' 'name: ask-matt' '---' > \
+  "$pinned_fixture/skills/engineering/ask-matt/SKILL.md"
+printf '%s\n' '---' 'name: to-spec' '---' > \
+  "$pinned_fixture/skills/engineering/to-spec/SKILL.md"
+fixture_archive="$TMP/pinned-mattpocock.tar.gz"
+tar -czf "$fixture_archive" -C "$TMP/pinned-mattpocock" skills-test
+download_log="$TMP/mattpocock-download.log"
+download_archive() {
+  printf '%s\n' "$1" > "$download_log"
+  cp "$fixture_archive" "$2"
+}
+
+reset_ownership_discovery
+mkdir -p "$AGENTS_SKILLS_DIR/to-spec"
+printf '%s\n' stale > "$AGENTS_SKILLS_DIR/to-spec/SKILL.md"
+if NPX_SKIP_SKILL=to-spec TMPDIR="$TMP" \
+  install_mattpocock_skill_names ask-matt to-spec; then
+  fail "stale Matt Pocock content was accepted as the pinned snapshot"
+fi
+rm -rf "$AGENTS_SKILLS_DIR/ask-matt" "$AGENTS_SKILLS_DIR/to-spec"
+mkdir -p "$(dirname "$GLOBAL_SKILL_LOCK_FILE")"
+printf '%s\n' '{"version":3,"skills":{"ask-matt":{"source":"mattpocock/skills"},"to-spec":{"source":"mattpocock/skills"},"custom-skill":{"source":"user/custom-skills"}}}' > \
+  "$GLOBAL_SKILL_LOCK_FILE"
+: > "$NPX_LOG"
+TMPDIR="$TMP" install_mattpocock_skill_names ask-matt to-spec || \
+  fail "pinned Matt Pocock snapshot install failed"
+grep -Fq "$MATTPOCOCK_COMMIT" "$download_log" || \
+  fail "Matt Pocock archive URL was not pinned to the release commit"
+grep -Fq "$TMP/mattpocock-skills." "$NPX_LOG" || \
+  fail "Matt Pocock skills were not installed from the local pinned snapshot"
+if grep -Fq 'add mattpocock/skills ' "$NPX_LOG"; then
+  fail "Matt Pocock install still passed the mutable remote source to npx"
+fi
+python3 - "$GLOBAL_SKILL_LOCK_FILE" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as fh:
+    skills = json.load(fh)["skills"]
+if "ask-matt" in skills or "to-spec" in skills:
+    raise SystemExit("remote Matt Pocock lock entries survived pinned installation")
+if skills.get("custom-skill", {}).get("source") != "user/custom-skills":
+    raise SystemExit("unrelated skill lock entry changed during pinned installation")
+PY
 
 printf '%s\n' "Codex skill reconciliation checks passed"

--- a/tests/install_ps1_skill_reconciliation.Tests.ps1
+++ b/tests/install_ps1_skill_reconciliation.Tests.ps1
@@ -99,6 +99,8 @@ $OWNERSHIP_SKILLS = @($MANAGED_SKILLS) + @($MATTPOCOCK_LEGACY_SKILLS)
 $script:SKIPPED_COMPONENTS = @()
 $script:SCRIPT_DIR = $repoRoot
 $script:MattPocockQuickstartReady = $true
+$script:MATTPOCOCK_VERSION = "v1.1.0"
+$script:MATTPOCOCK_COMMIT = "d574778f94cf620fcc8ce741584093bc650a61d3"
 $DryRun = $false
 
 $quickstart = @(Show-MattPocockQuickstart) -join "`n"
@@ -194,6 +196,28 @@ function npx {
     $global:LASTEXITCODE = 0
 }
 
+$script:DownloadUris = @()
+function Invoke-WebRequest {
+    param(
+        [string]$Uri,
+        [string]$OutFile,
+        [switch]$UseBasicParsing
+    )
+    $script:DownloadUris += $Uri
+    Set-Content -LiteralPath $OutFile -Value "fixture"
+}
+
+function tar {
+    $destinationIndex = [Array]::IndexOf($args, "-C")
+    if ($destinationIndex -lt 0) {
+        $global:LASTEXITCODE = 1
+        return
+    }
+    $destination = $args[$destinationIndex + 1]
+    Copy-Item -LiteralPath $script:PinnedFixtureRoot -Destination $destination -Recurse
+    $global:LASTEXITCODE = 0
+}
+
 try {
     New-Item -ItemType Directory -Path (Join-Path $CODEX_DIR "skills/pua") -Force | Out-Null
     New-Item -ItemType Directory -Path (Join-Path $CODEX_DIR "skills/handoff") -Force | Out-Null
@@ -270,6 +294,52 @@ try {
     Assert-True (-not $script:OwnedManagedSkills.Contains("to-issues")) "to-issues ownership should be removed"
     $lastNpxCall = $script:NpxCalls[-1]
     Assert-True ($lastNpxCall -contains "*") "legacy cleanup should remove all agent associations"
+
+    # Execute the pinned snapshot path itself: stale content must fail and
+    # clear previous ownership; a matching snapshot must use the immutable
+    # commit, install through a local source, and retire only matching locks.
+    $script:PinnedFixtureRoot = Join-Path $tempDir "pinned-fixture/skills-test"
+    foreach ($skill in @("ask-matt", "to-spec")) {
+        $skillDir = Join-Path $script:PinnedFixtureRoot "skills/engineering/$skill"
+        New-Item -ItemType Directory -Path $skillDir -Force | Out-Null
+        Set-Content -LiteralPath (Join-Path $skillDir "SKILL.md") -Value "name: $skill"
+    }
+
+    [System.IO.File]::WriteAllLines($MANAGED_SKILLS_STATE_FILE, @("ask-matt", "to-spec"))
+    $script:ManagedSkillOwnershipLoaded = $false
+    $script:OwnedManagedSkills = New-Object 'System.Collections.Generic.HashSet[string]'
+    $staleSkill = Join-Path $AGENTS_SKILLS_DIR "to-spec"
+    New-Item -ItemType Directory -Path $staleSkill -Force | Out-Null
+    Set-Content -LiteralPath (Join-Path $staleSkill "SKILL.md") -Value "stale"
+    $script:NpxSkipSkill = "to-spec"
+    $staleResult = Install-MattPocockSkillNames @("ask-matt", "to-spec")
+    Assert-True (-not $staleResult) "stale Matt Pocock content should fail pinned installation"
+    Assert-True (-not $script:OwnedManagedSkills.Contains("ask-matt")) "failed pinned install retained ask-matt ownership"
+    Assert-True (-not $script:OwnedManagedSkills.Contains("to-spec")) "failed pinned install retained to-spec ownership"
+
+    $script:NpxSkipSkill = $null
+    Remove-Item -LiteralPath (Join-Path $AGENTS_SKILLS_DIR "ask-matt") -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath (Join-Path $AGENTS_SKILLS_DIR "to-spec") -Recurse -Force -ErrorAction SilentlyContinue
+    Set-Content -LiteralPath $GLOBAL_SKILL_LOCK_FILE -Value '{"version":3,"skills":{"ask-matt":{"source":"mattpocock/skills"},"to-spec":{"source":"mattpocock/skills"},"custom-skill":{"source":"user/custom-skills"}}}'
+    $script:NpxCalls = @()
+    $pinnedResult = Install-MattPocockSkillNames @("ask-matt", "to-spec")
+    Assert-True $pinnedResult "matching pinned Matt Pocock snapshot should install"
+    Assert-True ($script:DownloadUris[-1] -like "*$($script:MATTPOCOCK_COMMIT)*") "archive URL should pin the release commit"
+    $pinnedNpxCall = $script:NpxCalls[-1]
+    Assert-True (-not ($pinnedNpxCall -contains "mattpocock/skills")) "pinned install should not pass mutable remote source to npx"
+    Assert-True (@($pinnedNpxCall | Where-Object { $_ -like "*mattpocock-skills.*" }).Count -gt 0) "pinned install should use a local snapshot path"
+    $lockAfterPinnedInstall = Get-Content -LiteralPath $GLOBAL_SKILL_LOCK_FILE -Raw | ConvertFrom-Json
+    Assert-True (-not $lockAfterPinnedInstall.skills.PSObject.Properties["ask-matt"]) "ask-matt remote lock should be retired"
+    Assert-True (-not $lockAfterPinnedInstall.skills.PSObject.Properties["to-spec"]) "to-spec remote lock should be retired"
+    Assert-True ($lockAfterPinnedInstall.skills.PSObject.Properties["custom-skill"].Value.source -ceq "user/custom-skills") "unrelated lock should be preserved"
+
+    $customReview = Join-Path $AGENTS_SKILLS_DIR "review"
+    New-Item -ItemType Directory -Path $customReview -Force | Out-Null
+    Set-Content -LiteralPath (Join-Path $customReview "SKILL.md") -Value "custom"
+    Set-Content -LiteralPath $GLOBAL_SKILL_LOCK_FILE -Value '{"version":3,"skills":{"review":{"source":"user/custom-skills"}}}'
+    $customLegacyResult = Remove-LegacyMattPocockSkills
+    Assert-True $customLegacyResult "custom legacy-name provenance check should succeed"
+    Assert-True (Test-Path $customReview) "custom same-name skill should be preserved"
 } finally {
     $env:PATH = $oldPath
     Remove-Item -Recurse -Force $tempDir -ErrorAction SilentlyContinue

--- a/tests/install_ps1_skill_reconciliation.Tests.ps1
+++ b/tests/install_ps1_skill_reconciliation.Tests.ps1
@@ -56,8 +56,14 @@ foreach ($name in @(
     "Add-ManagedSkillOwnership",
     "Remove-ManagedSkillOwnership",
     "Confirm-EmptySkillRemoval",
+    "Test-InstalledSkillNames",
+    "Remove-MattPocockSkillLockEntries",
+    "Install-NpxSkillNames",
+    "Install-MattPocockSkillNames",
     "Get-SelectedManagedSkills",
     "Remove-NpxSkillNames",
+    "Test-LockedSkillSource",
+    "Remove-LegacyMattPocockSkills",
     "Remove-SuperpowersFallback",
     "Sync-InteractiveSkills",
     "Show-MattPocockQuickstart"
@@ -71,13 +77,25 @@ function Write-Info { param($Message) }
 function Write-Ok { param($Message) }
 function Write-Warn { param($Message) }
 
-$MANAGED_SKILLS = @("humanizer", "humanizer-zh", "handoff", "pua", "brainstorming", "frontend-slides")
+$MANAGED_SKILLS = @(
+    "humanizer", "humanizer-zh", "handoff", "pua", "brainstorming", "frontend-slides",
+    "ask-matt", "diagnosing-bugs", "grill-with-docs", "triage", "implement",
+    "improve-codebase-architecture", "setup-matt-pocock-skills", "tdd",
+    "to-spec", "to-tickets", "wayfinder", "prototype", "domain-modeling",
+    "codebase-design", "grill-me", "grilling", "research", "teach", "writing-great-skills"
+)
 $SUPERPOWERS_SKILLS = @("brainstorming")
-$MATTPOCOCK_SKILLS = @("ask-matt")
+$MATTPOCOCK_SKILLS = @(
+    "ask-matt", "diagnosing-bugs", "grill-with-docs", "triage", "implement",
+    "improve-codebase-architecture", "setup-matt-pocock-skills", "tdd",
+    "to-spec", "to-tickets", "wayfinder", "prototype", "domain-modeling",
+    "codebase-design", "grill-me", "grilling", "research", "teach", "writing-great-skills"
+)
+$MATTPOCOCK_LEGACY_SKILLS = @("to-issues", "to-prd", "decision-mapping", "review")
 $PUA_SKILLS = @("pua", "pua-en", "pua-ja")
 $LOCAL_MANAGED_SKILLS = @("humanizer", "humanizer-zh", "handoff")
 $LEGACY_CLEANUP_SKILLS = @()
-$OWNERSHIP_SKILLS = @($MANAGED_SKILLS)
+$OWNERSHIP_SKILLS = @($MANAGED_SKILLS) + @($MATTPOCOCK_LEGACY_SKILLS)
 $script:SKIPPED_COMPONENTS = @()
 $script:SCRIPT_DIR = $repoRoot
 $script:MattPocockQuickstartReady = $true
@@ -107,6 +125,15 @@ $script:SelectSkillPaperReading = $false
 $script:SelectSkillHumanizer = $true
 $script:SelectSkillHumanizerZh = $false
 $script:SelectSkillHandoff = $false
+$script:SelectSkillMattPocock = $true
+$selected = @(Get-SelectedManagedSkills)
+foreach ($skill in @("to-spec", "to-tickets", "wayfinder")) {
+    Assert-True ($selected -contains $skill) "Matt Pocock selection is missing v1.1 skill: $skill"
+}
+foreach ($skill in $MATTPOCOCK_LEGACY_SKILLS) {
+    Assert-True (-not ($selected -contains $skill)) "Matt Pocock selection still exposes retired skill: $skill"
+}
+$script:SelectSkillMattPocock = $false
 $script:SelectSkillAdversarialReview = $false
 $script:SelectSkillUpdate = $false
 $script:SelectAiTokenization = $false
@@ -142,6 +169,28 @@ $script:NpxCalls = @()
 
 function npx {
     $script:NpxCalls += ,@($args)
+    $isAdd = $args -contains "add"
+    $isRemove = $args -contains "remove"
+    if ($isAdd) {
+        for ($i = 0; $i -lt $args.Count - 1; $i++) {
+            if ($args[$i] -ceq "--skill") {
+                $skill = $args[$i + 1]
+                if ($skill -cne $script:NpxSkipSkill) {
+                    $skillDir = Join-Path $AGENTS_SKILLS_DIR $skill
+                    New-Item -ItemType Directory -Path $skillDir -Force | Out-Null
+                    Set-Content -LiteralPath (Join-Path $skillDir "SKILL.md") -Value "name: $skill"
+                }
+            }
+        }
+    }
+    if ($isRemove -and $args -contains "*") {
+        $removeIndex = [Array]::IndexOf($args, "remove")
+        for ($i = $removeIndex + 1; $i -lt $args.Count; $i++) {
+            if ($args[$i].StartsWith("--")) { break }
+            Remove-Item -LiteralPath (Join-Path $AGENTS_SKILLS_DIR $args[$i]) `
+                -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
     $global:LASTEXITCODE = 0
 }
 
@@ -189,6 +238,38 @@ try {
     $script:OwnedManagedSkills = New-Object 'System.Collections.Generic.HashSet[string]'
     Initialize-ManagedSkillOwnership
     Assert-True ($script:OwnedManagedSkills.Contains("frontend-slides")) "matching lock/canonical copy should be adopted"
+
+    # A successful npx exit must not hide a missing requested skill.
+    Remove-Item -Force $MANAGED_SKILLS_STATE_FILE -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath (Join-Path $AGENTS_SKILLS_DIR "to-spec") -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath (Join-Path $AGENTS_SKILLS_DIR "to-tickets") -Recurse -Force -ErrorAction SilentlyContinue
+    $script:ManagedSkillOwnershipLoaded = $false
+    $script:OwnedManagedSkills = New-Object 'System.Collections.Generic.HashSet[string]'
+    $script:NpxSkipSkill = "to-tickets"
+    $partialResult = Install-NpxSkillNames "mattpocock/skills" @("to-spec", "to-tickets")
+    Assert-True (-not $partialResult) "partial npx install should not report success"
+    Assert-True (-not $script:OwnedManagedSkills.Contains("to-spec")) "partial install should not record ownership"
+    Assert-True (-not $script:OwnedManagedSkills.Contains("to-tickets")) "missing skill should not record ownership"
+    $script:NpxSkipSkill = $null
+
+    # Retired Matt Pocock names are removed from the canonical shared path and
+    # from ownership using all-agent cleanup.
+    [System.IO.File]::WriteAllLines($MANAGED_SKILLS_STATE_FILE, @("to-prd", "to-issues"))
+    $script:ManagedSkillOwnershipLoaded = $false
+    $script:OwnedManagedSkills = New-Object 'System.Collections.Generic.HashSet[string]'
+    foreach ($skill in @("to-prd", "to-issues")) {
+        $skillDir = Join-Path $AGENTS_SKILLS_DIR $skill
+        New-Item -ItemType Directory -Path $skillDir -Force | Out-Null
+        Set-Content -LiteralPath (Join-Path $skillDir "SKILL.md") -Value "legacy"
+    }
+    $legacyResult = Remove-LegacyMattPocockSkills
+    Assert-True $legacyResult "legacy Matt Pocock cleanup should succeed"
+    Assert-True (-not (Test-Path (Join-Path $AGENTS_SKILLS_DIR "to-prd"))) "to-prd should be removed"
+    Assert-True (-not (Test-Path (Join-Path $AGENTS_SKILLS_DIR "to-issues"))) "to-issues should be removed"
+    Assert-True (-not $script:OwnedManagedSkills.Contains("to-prd")) "to-prd ownership should be removed"
+    Assert-True (-not $script:OwnedManagedSkills.Contains("to-issues")) "to-issues ownership should be removed"
+    $lastNpxCall = $script:NpxCalls[-1]
+    Assert-True ($lastNpxCall -contains "*") "legacy cleanup should remove all agent associations"
 } finally {
     $env:PATH = $oldPath
     Remove-Item -Recurse -Force $tempDir -ErrorAction SilentlyContinue

--- a/tests/install_ps1_skill_reconciliation.Tests.ps1
+++ b/tests/install_ps1_skill_reconciliation.Tests.ps1
@@ -160,12 +160,14 @@ Assert-True ($selected -contains "handoff") "an explicitly selected handoff sour
 $script:SelectSkillHandoff = $false
 
 $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ("codex-skill-reconciliation-test-" + [guid]::NewGuid().ToString("N"))
+$oldXdgStateHome = $env:XDG_STATE_HOME
+$env:XDG_STATE_HOME = Join-Path $tempDir "xdg-state"
 $CODEX_DIR = Join-Path $tempDir ".codex"
 $AGENTS_SKILLS_DIR = Join-Path $tempDir ".agents/skills"
 $SUPERPOWERS_DIR = Join-Path $CODEX_DIR "superpowers"
 $SUPERPOWERS_LINK = Join-Path $AGENTS_SKILLS_DIR "superpowers"
 $MANAGED_SKILLS_STATE_FILE = Join-Path $CODEX_DIR ".awesome-claude-code-config-managed-skills"
-$GLOBAL_SKILL_LOCK_FILE = Join-Path $tempDir ".agents/.skill-lock.json"
+$GLOBAL_SKILL_LOCK_FILE = Join-Path $env:XDG_STATE_HOME "skills/.skill-lock.json"
 $script:ManagedSkillOwnershipLoaded = $false
 $script:OwnedManagedSkills = New-Object 'System.Collections.Generic.HashSet[string]'
 $Force = $true
@@ -379,6 +381,11 @@ try {
     Assert-True (Test-Path $customReview) "custom same-name skill should be preserved"
 } finally {
     $env:PATH = $oldPath
+    if ($null -eq $oldXdgStateHome) {
+        Remove-Item Env:XDG_STATE_HOME -ErrorAction SilentlyContinue
+    } else {
+        $env:XDG_STATE_HOME = $oldXdgStateHome
+    }
     Remove-Item -Recurse -Force $tempDir -ErrorAction SilentlyContinue
 }
 

--- a/tests/install_ps1_skill_reconciliation.Tests.ps1
+++ b/tests/install_ps1_skill_reconciliation.Tests.ps1
@@ -72,6 +72,8 @@ foreach ($name in @(
     Assert-True ($null -ne $functionText) "install.ps1 should define $name"
     Invoke-Expression $functionText
 }
+$realRemoveMattPocockSkillLockEntries =
+    (Get-Item Function:\Remove-MattPocockSkillLockEntries).ScriptBlock
 
 function Write-Info { param($Message) }
 function Write-Ok { param($Message) }
@@ -127,15 +129,6 @@ $script:SelectSkillPaperReading = $false
 $script:SelectSkillHumanizer = $true
 $script:SelectSkillHumanizerZh = $false
 $script:SelectSkillHandoff = $false
-$script:SelectSkillMattPocock = $true
-$selected = @(Get-SelectedManagedSkills)
-foreach ($skill in @("to-spec", "to-tickets", "wayfinder")) {
-    Assert-True ($selected -contains $skill) "Matt Pocock selection is missing v1.1 skill: $skill"
-}
-foreach ($skill in $MATTPOCOCK_LEGACY_SKILLS) {
-    Assert-True (-not ($selected -contains $skill)) "Matt Pocock selection still exposes retired skill: $skill"
-}
-$script:SelectSkillMattPocock = $false
 $script:SelectSkillAdversarialReview = $false
 $script:SelectSkillUpdate = $false
 $script:SelectAiTokenization = $false
@@ -145,6 +138,16 @@ $script:SelectAiDistributedTraining = $false
 $script:SelectAiInferenceServing = $false
 $script:SelectAiOptimization = $false
 $script:SelectAiDeepXiv = $false
+
+$script:SelectSkillMattPocock = $true
+$selected = @(Get-SelectedManagedSkills)
+foreach ($skill in @("to-spec", "to-tickets", "wayfinder")) {
+    Assert-True ($selected -contains $skill) "Matt Pocock selection is missing v1.1 skill: $skill"
+}
+foreach ($skill in $MATTPOCOCK_LEGACY_SKILLS) {
+    Assert-True (-not ($selected -contains $skill)) "Matt Pocock selection still exposes retired skill: $skill"
+}
+$script:SelectSkillMattPocock = $false
 
 $selected = @(Get-SelectedManagedSkills)
 Assert-True ($selected -contains "humanizer") "selected local skill should be desired"
@@ -156,7 +159,7 @@ $selected = @(Get-SelectedManagedSkills)
 Assert-True ($selected -contains "handoff") "an explicitly selected handoff source should be retained"
 $script:SelectSkillHandoff = $false
 
-$tempDir = Join-Path $env:TEMP ("codex-skill-reconciliation-test-" + [guid]::NewGuid().ToString("N"))
+$tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ("codex-skill-reconciliation-test-" + [guid]::NewGuid().ToString("N"))
 $CODEX_DIR = Join-Path $tempDir ".codex"
 $AGENTS_SKILLS_DIR = Join-Path $tempDir ".agents/skills"
 $SUPERPOWERS_DIR = Join-Path $CODEX_DIR "superpowers"
@@ -186,11 +189,20 @@ function npx {
         }
     }
     if ($isRemove -and $args -contains "*") {
+        # skills@1.5.16 rejects the documented wildcard agent. The production
+        # installer must omit --agent to target every agent.
+        $global:LASTEXITCODE = 1
+        return
+    }
+    $removeAllAgents = $isRemove -and -not ($args -contains "--agent")
+    if ($isRemove) {
         $removeIndex = [Array]::IndexOf($args, "remove")
         for ($i = $removeIndex + 1; $i -lt $args.Count; $i++) {
             if ($args[$i].StartsWith("--")) { break }
-            Remove-Item -LiteralPath (Join-Path $AGENTS_SKILLS_DIR $args[$i]) `
-                -Recurse -Force -ErrorAction SilentlyContinue
+            if ($removeAllAgents) {
+                Remove-Item -LiteralPath (Join-Path $AGENTS_SKILLS_DIR $args[$i]) `
+                    -Recurse -Force -ErrorAction SilentlyContinue
+            }
         }
     }
     $global:LASTEXITCODE = 0
@@ -286,6 +298,7 @@ try {
         New-Item -ItemType Directory -Path $skillDir -Force | Out-Null
         Set-Content -LiteralPath (Join-Path $skillDir "SKILL.md") -Value "legacy"
     }
+    Set-Content -LiteralPath $GLOBAL_SKILL_LOCK_FILE -Value '{"version":3,"skills":{"to-prd":{"source":"mattpocock/skills"},"to-issues":{"source":"mattpocock/skills"},"custom-skill":{"source":"user/custom-skills"}}}'
     $legacyResult = Remove-LegacyMattPocockSkills
     Assert-True $legacyResult "legacy Matt Pocock cleanup should succeed"
     Assert-True (-not (Test-Path (Join-Path $AGENTS_SKILLS_DIR "to-prd"))) "to-prd should be removed"
@@ -293,7 +306,12 @@ try {
     Assert-True (-not $script:OwnedManagedSkills.Contains("to-prd")) "to-prd ownership should be removed"
     Assert-True (-not $script:OwnedManagedSkills.Contains("to-issues")) "to-issues ownership should be removed"
     $lastNpxCall = $script:NpxCalls[-1]
-    Assert-True ($lastNpxCall -contains "*") "legacy cleanup should remove all agent associations"
+    Assert-True (-not ($lastNpxCall -contains "*")) "legacy cleanup should not pass the CLI's invalid wildcard agent"
+    Assert-True (-not ($lastNpxCall -contains "--agent")) "legacy cleanup should use default all-agent removal"
+    $lockAfterLegacyCleanup = Get-Content -LiteralPath $GLOBAL_SKILL_LOCK_FILE -Raw | ConvertFrom-Json
+    Assert-True (-not $lockAfterLegacyCleanup.skills.PSObject.Properties["to-prd"]) "to-prd lock should be retired"
+    Assert-True (-not $lockAfterLegacyCleanup.skills.PSObject.Properties["to-issues"]) "to-issues lock should be retired"
+    Assert-True ($lockAfterLegacyCleanup.skills.PSObject.Properties["custom-skill"].Value.source -ceq "user/custom-skills") "legacy cleanup should preserve unrelated locks"
 
     # Execute the pinned snapshot path itself: stale content must fail and
     # clear previous ownership; a matching snapshot must use the immutable
@@ -332,6 +350,25 @@ try {
     Assert-True (-not $lockAfterPinnedInstall.skills.PSObject.Properties["ask-matt"]) "ask-matt remote lock should be retired"
     Assert-True (-not $lockAfterPinnedInstall.skills.PSObject.Properties["to-spec"]) "to-spec remote lock should be retired"
     Assert-True ($lockAfterPinnedInstall.skills.PSObject.Properties["custom-skill"].Value.source -ceq "user/custom-skills") "unrelated lock should be preserved"
+
+    # An exception after npx has recorded ownership must still fail closed and
+    # clear every requested ownership record.
+    Remove-ManagedSkillOwnership @("ask-matt", "to-spec")
+    Remove-Item -LiteralPath (Join-Path $AGENTS_SKILLS_DIR "ask-matt") -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath (Join-Path $AGENTS_SKILLS_DIR "to-spec") -Recurse -Force -ErrorAction SilentlyContinue
+    function Remove-MattPocockSkillLockEntries {
+        param([string[]]$SkillNames)
+        throw "injected lock cleanup failure"
+    }
+    try {
+        $exceptionResult = Install-MattPocockSkillNames @("ask-matt", "to-spec")
+        Assert-True (-not $exceptionResult) "lock cleanup exception should fail pinned installation"
+        Assert-True (-not $script:OwnedManagedSkills.Contains("ask-matt")) "exception retained ask-matt ownership"
+        Assert-True (-not $script:OwnedManagedSkills.Contains("to-spec")) "exception retained to-spec ownership"
+    } finally {
+        Set-Item -Path Function:\Remove-MattPocockSkillLockEntries `
+            -Value $realRemoveMattPocockSkillLockEntries
+    }
 
     $customReview = Join-Path $AGENTS_SKILLS_DIR "review"
     New-Item -ItemType Directory -Path $customReview -Force | Out-Null

--- a/tests/install_ps1_skill_reconciliation.Tests.ps1
+++ b/tests/install_ps1_skill_reconciliation.Tests.ps1
@@ -45,6 +45,7 @@ function Get-FunctionText {
 }
 
 foreach ($name in @(
+    "Get-GlobalSkillLockFile",
     "Test-SkillInList",
     "Test-ManagedSkillName",
     "Get-ExpectedSkillSource",
@@ -74,6 +75,20 @@ foreach ($name in @(
 }
 $realRemoveMattPocockSkillLockEntries =
     (Get-Item Function:\Remove-MattPocockSkillLockEntries).ScriptBlock
+
+$lockPathFixture = Join-Path ([System.IO.Path]::GetTempPath()) "codex-lock-path-fixture"
+$xdgLockPath = Get-GlobalSkillLockFile `
+    -HomePath (Join-Path $lockPathFixture "home") `
+    -XdgStateHome (Join-Path $lockPathFixture "state")
+Assert-True `
+    ($xdgLockPath -ceq (Join-Path $lockPathFixture "state/skills/.skill-lock.json")) `
+    "global skill lock path should honor XDG_STATE_HOME"
+$homeLockPath = Get-GlobalSkillLockFile `
+    -HomePath (Join-Path $lockPathFixture "home") `
+    -XdgStateHome ""
+Assert-True `
+    ($homeLockPath -ceq (Join-Path $lockPathFixture "home/.agents/.skill-lock.json")) `
+    "global skill lock path should fall back to HOME"
 
 function Write-Info { param($Message) }
 function Write-Ok { param($Message) }
@@ -167,7 +182,9 @@ $AGENTS_SKILLS_DIR = Join-Path $tempDir ".agents/skills"
 $SUPERPOWERS_DIR = Join-Path $CODEX_DIR "superpowers"
 $SUPERPOWERS_LINK = Join-Path $AGENTS_SKILLS_DIR "superpowers"
 $MANAGED_SKILLS_STATE_FILE = Join-Path $CODEX_DIR ".awesome-claude-code-config-managed-skills"
-$GLOBAL_SKILL_LOCK_FILE = Join-Path $env:XDG_STATE_HOME "skills/.skill-lock.json"
+$GLOBAL_SKILL_LOCK_FILE = Get-GlobalSkillLockFile `
+    -HomePath $HOME `
+    -XdgStateHome $env:XDG_STATE_HOME
 $script:ManagedSkillOwnershipLoaded = $false
 $script:OwnedManagedSkills = New-Object 'System.Collections.Generic.HashSet[string]'
 $Force = $true


### PR DESCRIPTION
## Summary

- migrate the managed Matt Pocock workflow set to v1.1 names (`to-spec`, `to-tickets`, `wayfinder`)
- install from the immutable v1.1.0 release commit instead of mutable remote resolution
- reject partial or stale installs and clear ownership on failure
- remove provenance-verified retired names across shared agent associations
- retire matching remote lock entries so generic `skills update` cannot overwrite pinned content
- keep Bash and PowerShell behavior, tests, README files, and changelogs aligned

## Root cause

`skills@latest add` returns success even when requested skill names no longer exist. The previous manifest still requested `to-prd` and `to-issues`, so installation completed with only the surviving subset. Cleanup also checked `~/.codex/skills` while global Codex skills commonly live under `~/.agents/skills`, leaving retired entries behind.

Remote tag/commit suffixes were also observed resolving inconsistently, so the installers now download commit `d574778f94cf620fcc8ce741584093bc650a61d3` and pass the extracted local snapshot to the skills CLI.

## Maintainer review fixes

- use the Skills CLI default all-agent removal path because `skills@1.5.16` rejects the documented `--agent '*'`
- explicitly retire matching legacy lock-only entries and preserve unrelated lock sources
- match the CLI's `$XDG_STATE_HOME/skills/.skill-lock.json` override, with direct XDG and HOME fallback tests
- clear PowerShell ownership when an exception occurs after a pinned install records ownership
- make the PowerShell reconciliation fixture executable cross-platform

## Verification

- `bash tests/check_codex_migration.sh`
- `bash tests/check_codex_skill_reconciliation.sh`
- `bash tests/check_playwright_mcp_installation.sh`
- `pwsh -NoProfile -File tests/install_ps1_skill_reconciliation.Tests.ps1`
- `pwsh -NoProfile -File tests/install_ps1_playwright_mcp.Tests.ps1`
- Bash and PowerShell syntax parsing
- `git diff --check`
- isolated real install of all 20 selected Matt skills: 0 content mismatches, 0 remaining remote Matt lock entries, 20 ownership records
- isolated `skills@1.5.16` reproduction: wildcard removal failed; default all-agent removal succeeded
- final two-axis review: Standards Hard 0 / Judgement 0; Spec 0

RED/GREEN checkpoints and exact evidence are recorded in [`docs/testing/matt-pocock-v1.1-migration.tdd.md`](docs/testing/matt-pocock-v1.1-migration.tdd.md).

## Platform note

The PowerShell suites were executed with a temporary PowerShell 7.6.3 runtime verified against Microsoft's published SHA-256. Native Windows PowerShell 5.1 remains the Windows compatibility gate.
