### PR TITLE
fix(codex): guard empty arrays on macOS Bash 3.2

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1949,7 +1949,8 @@ reconcile_interactive_skills() {
         npx_removal_succeeded=true
       fi
 
-      if $npx_removal_succeeded && ! $DRY_RUN; then
+      if $npx_removal_succeeded && ! $DRY_RUN &&
+         [[ ${#verified_npx_skills[@]} -gt 0 ]]; then
         for skill in "${verified_npx_skills[@]}"; do
           rm -rf "$CODEX_DIR/skills/$skill"
         done
@@ -1957,15 +1958,17 @@ reconcile_interactive_skills() {
 
       local restoration_failed=false
       if ! $DRY_RUN && [[ -n "$protection_dir" ]]; then
-        for skill in "${protected_npx_skills[@]}"; do
-          local codex_skill_path="$CODEX_DIR/skills/$skill"
-          rm -rf "$codex_skill_path"
-          mkdir -p "$(dirname "$codex_skill_path")"
-          if ! mv "$protection_dir/$skill" "$codex_skill_path"; then
-            restoration_failed=true
-            warn "Could not restore the protected user skill; recover it from $protection_dir/$skill"
-          fi
-        done
+        if [[ ${#protected_npx_skills[@]} -gt 0 ]]; then
+          for skill in "${protected_npx_skills[@]}"; do
+            local codex_skill_path="$CODEX_DIR/skills/$skill"
+            rm -rf "$codex_skill_path"
+            mkdir -p "$(dirname "$codex_skill_path")"
+            if ! mv "$protection_dir/$skill" "$codex_skill_path"; then
+              restoration_failed=true
+              warn "Could not restore the protected user skill; recover it from $protection_dir/$skill"
+            fi
+          done
+        fi
         if ! $restoration_failed; then
           rm -rf "$protection_dir"
         fi
@@ -1976,23 +1979,25 @@ reconcile_interactive_skills() {
       fi
     fi
 
-    for skill in "${direct_stale[@]}"; do
-      if $DRY_RUN; then
-        if [[ -e "$CODEX_DIR/skills/$skill" || -L "$CODEX_DIR/skills/$skill" ]]; then
-          info "Would remove unselected managed skill: $CODEX_DIR/skills/$skill"
-        fi
-      elif [[ -e "$CODEX_DIR/skills/$skill" || -L "$CODEX_DIR/skills/$skill" ]]; then
-        if rm -rf "$CODEX_DIR/skills/$skill"; then
-          ok "Removed unselected managed skill: $skill"
-          removed_stale+=("$skill")
+    if [[ ${#direct_stale[@]} -gt 0 ]]; then
+      for skill in "${direct_stale[@]}"; do
+        if $DRY_RUN; then
+          if [[ -e "$CODEX_DIR/skills/$skill" || -L "$CODEX_DIR/skills/$skill" ]]; then
+            info "Would remove unselected managed skill: $CODEX_DIR/skills/$skill"
+          fi
+        elif [[ -e "$CODEX_DIR/skills/$skill" || -L "$CODEX_DIR/skills/$skill" ]]; then
+          if rm -rf "$CODEX_DIR/skills/$skill"; then
+            ok "Removed unselected managed skill: $skill"
+            removed_stale+=("$skill")
+          else
+            warn "Could not remove unselected managed skill: $skill"
+            SKIPPED_COMPONENTS+=("unselected managed skill removal failed: $skill")
+          fi
         else
-          warn "Could not remove unselected managed skill: $skill"
-          SKIPPED_COMPONENTS+=("unselected managed skill removal failed: $skill")
+          removed_stale+=("$skill")
         fi
-      else
-        removed_stale+=("$skill")
-      fi
-    done
+      done
+    fi
     if $researchstudio_removed && [[ -f "$CODEX_DIR/skills/.env" ]]; then
       warn "Preserving $CODEX_DIR/skills/.env because it may contain user-managed ResearchStudio credentials; remove it manually if no other skill uses it"
     fi

--- a/tests/check_codex_skill_reconciliation.sh
+++ b/tests/check_codex_skill_reconciliation.sh
@@ -282,6 +282,16 @@ reconcile_interactive_skills
 assert_exists "$SUPERPOWERS_LINK"
 assert_exists "$SUPERPOWERS_DIR"
 
+# A first-run migration can adopt only the superpowers fallback while no
+# matching ~/.codex/skills copies exist. All npx cleanup arrays stay empty.
+reset_ownership_discovery
+reconcile_interactive_skills
+assert_missing "$SUPERPOWERS_LINK"
+assert_missing "$SUPERPOWERS_DIR"
+
+mkdir -p "$SUPERPOWERS_DIR/skills" "$SUPERPOWERS_DIR/.git"
+printf '%s\n' '[remote "origin"]' '  url = https://github.com/obra/superpowers.git' > "$SUPERPOWERS_DIR/.git/config"
+ln -s "$SUPERPOWERS_DIR/skills" "$SUPERPOWERS_LINK"
 mkdir -p "$CODEX_DIR/skills/pua" "$AGENTS_SKILLS_DIR/pua"
 printf '%s\n' managed > "$CODEX_DIR/skills/pua/SKILL.md"
 printf '%s\n' managed > "$AGENTS_SKILLS_DIR/pua/SKILL.md"

--- a/tests/check_codex_skill_reconciliation.sh
+++ b/tests/check_codex_skill_reconciliation.sh
@@ -3,7 +3,16 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TMP="$(mktemp -d)"
-trap 'rm -rf "$TMP"' EXIT
+TEST_COMPLETED=false
+cleanup() {
+  local status=$?
+  if [[ $status -eq 0 && "$TEST_COMPLETED" != "true" ]]; then
+    status=1
+  fi
+  rm -rf "$TMP"
+  exit "$status"
+}
+trap cleanup EXIT
 
 export HOME="$TMP/home"
 export XDG_STATE_HOME="$TMP/xdg-state"
@@ -482,4 +491,5 @@ if skills.get("custom-skill", {}).get("source") != "user/custom-skills":
     raise SystemExit("unrelated skill lock entry changed during pinned installation")
 PY
 
+TEST_COMPLETED=true
 printf '%s\n' "Codex skill reconciliation checks passed"


### PR DESCRIPTION
## Summary
- preserve non-zero test outcomes when Bash 3.2 aborts before the success marker
- guard empty verified, protected, and direct stale skill arrays during interactive reconciliation
- cover the legacy obra/superpowers fallback path with no ~/.codex/skills copies

## Root cause
macOS /bin/bash 3.2 treats expansion of an empty array under set -u as an unbound variable. The default interactive selection can adopt an existing superpowers fallback while all cleanup arrays remain empty, aborting before Core/MCP installation and the version stamp.

## Verification
- /bin/bash -n install.sh
- /bin/bash tests/check_codex_skill_reconciliation.sh
- PATH=<Python 3.12 shim> bash tests/check_codex_migration.sh
- bash scripts/check-readme-sync.sh
- pytest: 89 passed, 9 skipped
- git diff --check